### PR TITLE
fix: use x and y values from onActive handler to support new RNGH web implementation

### DIFF
--- a/docusaurus/docs/API/ColorPicker.md
+++ b/docusaurus/docs/API/ColorPicker.md
@@ -104,6 +104,6 @@ All built-in components should be wrapped within the `ColorPicker` component.
 
 - Triggered upon the user releasing the slider handle or clicking on a swatch.
 - The passed color object has the following properties: `hex`, `rgb`, `rgba`, `hsv`, `hsva`, `hwb`, `hwba`, `hsl`, and `hsla`
-- As of this writing, the new `react-native-gesture-handler` implementation does not support the events which trigger this callback
+- As of `react-native-gesture-handler@2.9.0` the new web implementation does not support the events which trigger this callback
 - `type: (color: object) => void`
 - `default: null`

--- a/docusaurus/docs/API/ColorPicker.md
+++ b/docusaurus/docs/API/ColorPicker.md
@@ -104,5 +104,6 @@ All built-in components should be wrapped within the `ColorPicker` component.
 
 - Triggered upon the user releasing the slider handle or clicking on a swatch.
 - The passed color object has the following properties: `hex`, `rgb`, `rgba`, `hsv`, `hsva`, `hwb`, `hwba`, `hsl`, and `hsla`
+- As of this writing, the new `react-native-gesture-handler` implementation does not support the events which trigger this callback
 - `type: (color: object) => void`
 - `default: null`

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -71,10 +71,10 @@ export function BrightnessSlider({
       onActive: (event, ctx) => {
         const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
 
-        const x = event.translationX,
-          y = event.translationY,
-          posX = clamp(x + ctx.x, width.value),
-          posY = clamp(y + ctx.y, height.value),
+        const x = event.x,
+          y = event.y,
+          posX = clamp(x, width.value),
+          posY = clamp(y, height.value),
           percentX = posX / width.value,
           percentY = posY / height.value,
           brightnessX = reverse ? 100 - Math.round(percentX * 100) : Math.round(percentX * 100),

--- a/src/components/HueSlider.tsx
+++ b/src/components/HueSlider.tsx
@@ -61,10 +61,10 @@ export function HueSlider({ thumbShape, thumbSize, thumbColor, style = {}, verti
       onActive: (event, ctx) => {
         const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
 
-        const x = event.translationX,
-          y = event.translationY,
-          posX = clamp(x + ctx.x, width.value),
-          posY = clamp(y + ctx.y, height.value),
+        const x = event.x,
+          y = event.y,
+          posX = clamp(x, width.value),
+          posY = clamp(y, height.value),
           percentX = posX / width.value,
           percentY = posY / height.value,
           hueX = reverse ? 360 - Math.round(percentX * 360) : Math.round(percentX * 360),

--- a/src/components/OpacitySlider.tsx
+++ b/src/components/OpacitySlider.tsx
@@ -64,10 +64,10 @@ export function OpacitySlider({ thumbShape, thumbSize, thumbColor, style = {}, v
       onActive: (event, ctx) => {
         const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
 
-        const x = event.translationX,
-          y = event.translationY,
-          posX = clamp(x + ctx.x, width.value),
-          posY = clamp(y + ctx.y, height.value),
+        const x = event.x,
+          y = event.y,
+          posX = clamp(x, width.value),
+          posY = clamp(y, height.value),
           percentX = posX / width.value,
           percentY = posY / height.value,
           opacityX = reverse ? 100 - Math.round(percentX * 100) : Math.round(percentX * 100),

--- a/src/components/Panel1.tsx
+++ b/src/components/Panel1.tsx
@@ -56,10 +56,10 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     onActive: (event, ctx) => {
       const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
 
-      const x = event.translationX,
-        y = event.translationY,
-        posX = clamp(x + ctx.x, width.value),
-        posY = clamp(y + ctx.y, height.value),
+      const x = event.x,
+          y = event.y,
+          posX = clamp(x, width.value),
+          posY = clamp(y, height.value),
         percentX = posX / width.value,
         percentY = posY / height.value;
 

--- a/src/components/Panel2.tsx
+++ b/src/components/Panel2.tsx
@@ -54,10 +54,10 @@ export function Panel2({ thumbShape, thumbSize, thumbColor, reverse = false, sty
       onActive: (event, ctx) => {
         const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
 
-        const x = event.translationX,
-          y = event.translationY,
-          posX = clamp(x + ctx.x, width.value),
-          posY = clamp(y + ctx.y, height.value),
+        const x = event.x,
+          y = event.y,
+          posX = clamp(x, width.value),
+          posY = clamp(y, height.value),
           percentX = posX / width.value,
           percentY = posY / height.value;
 

--- a/src/components/SaturationSlider.tsx
+++ b/src/components/SaturationSlider.tsx
@@ -71,10 +71,10 @@ export function SaturationSlider({
       onActive: (event, ctx) => {
         const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
 
-        const x = event.translationX,
-          y = event.translationY,
-          posX = clamp(x + ctx.x, width.value),
-          posY = clamp(y + ctx.y, height.value),
+        const x = event.x,
+          y = event.y,
+          posX = clamp(x, width.value),
+          posY = clamp(y, height.value),
           percentX = posX / width.value,
           percentY = posY / height.value,
           saturationX = reverse ? 100 - Math.round(percentX * 100) : Math.round(percentX * 100),


### PR DESCRIPTION
Sliders do not work with [the new RNGH web implementation](https://github.com/software-mansion/react-native-gesture-handler/pull/2394) because the new web implementation does not trigger the `onStart` or `onFinish` GH events (or `onCancel` and `onEnd`), so `ColorPicker`'s `onComplete` prop does not fire and the `onActive` callback does not include the `ctx` arg .

On the plus side, the new web implementation _does_ handle the `minDist` prop correctly, allowing the user to click a location in order to update the thumb position without having to drag.