### PR TITLE
set hsva values in onStart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reanimated-color-picker",
-  "version": "1.0.2",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reanimated-color-picker",
-      "version": "1.0.2",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.18.6",

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -83,10 +83,10 @@ export function BrightnessSlider({
     {
       onStart: (event) => {
         handleScale.value = withTiming(1.2, { duration: 100 });
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
       },
       onActive: (event) => {
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
         runOnJS(onGestureChange)();
       },
       onFinish: () => {

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -77,6 +77,8 @@ export function BrightnessSlider({
       valY = reverse ? 100 - Math.round(percentY * 100) : Math.round(percentY * 100);
 
     brightnessValue.value = vertical ? valY : valX;
+
+    runOnJS(onGestureChange)();
   }
 
   const gestureEvent = useAnimatedGestureHandler(
@@ -87,7 +89,6 @@ export function BrightnessSlider({
       },
       onActive: (event) => {
         setValueFromGestureEvent(event);
-        runOnJS(onGestureChange)();
       },
       onFinish: () => {
         handleScale.value = withTiming(1, { duration: 100 });

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -28,7 +28,6 @@ export function BrightnessSlider({
   const {
     brightnessValue,
     hueValue,
-    saturationValue,
     onGestureChange,
     onGestureEnd,
     sliderThickness,
@@ -61,7 +60,7 @@ export function BrightnessSlider({
     };
   }, [thumbSize, vertical, reverse]);
 
-  const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, ${saturationValue.value}%, 50%)` }));
+  const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, 100%, 50%)` }));
 
   const clamp = (v: number, max: number) => {
     'worklet';

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -67,7 +67,7 @@ export function BrightnessSlider({
     return Math.min(Math.max(v, 0), max);
   };
 
-  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -62,9 +62,13 @@ export function BrightnessSlider({
 
   const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, 100%, 50%)` }));
 
-  const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
+  const clamp = (v: number, max: number) => {
+    'worklet';
+    return Math.min(Math.max(v, 0), max);
+  };
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+    'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
       percentX = posX / width.value,

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -79,15 +79,15 @@ export function BrightnessSlider({
     brightnessValue.value = vertical ? valY : valX;
 
     runOnJS(onGestureChange)();
-  }
+  };
 
   const gestureEvent = useAnimatedGestureHandler(
     {
-      onStart: (event) => {
+      onStart: event => {
         handleScale.value = withTiming(1.2, { duration: 100 });
         setValueFromGestureEvent(event);
       },
-      onActive: (event) => {
+      onActive: event => {
         setValueFromGestureEvent(event);
       },
       onFinish: () => {

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -28,6 +28,7 @@ export function BrightnessSlider({
   const {
     brightnessValue,
     hueValue,
+    saturationValue,
     onGestureChange,
     onGestureEnd,
     sliderThickness,
@@ -60,7 +61,7 @@ export function BrightnessSlider({
     };
   }, [thumbSize, vertical, reverse]);
 
-  const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, 100%, 50%)` }));
+  const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, ${saturationValue.value}%, 50%)` }));
 
   const clamp = (v: number, max: number) => {
     'worklet';

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -95,7 +95,7 @@ export function BrightnessSlider({
         runOnJS(onGestureEnd)();
       },
     },
-    [thumbSize, vertical, reverse]
+    [width.value, height.value, vertical, reverse]
   );
 
   const onLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {

--- a/src/components/HueSlider.tsx
+++ b/src/components/HueSlider.tsx
@@ -73,10 +73,10 @@ export function HueSlider({ thumbShape, thumbSize, thumbColor, style = {}, verti
     {
       onStart: (event) => {
         handleScale.value = withTiming(1.2, { duration: 100 });
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
       },
       onActive: (event) => {
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
         runOnJS(onGestureChange)();
       },
       onFinish: () => {

--- a/src/components/HueSlider.tsx
+++ b/src/components/HueSlider.tsx
@@ -57,7 +57,7 @@ export function HueSlider({ thumbShape, thumbSize, thumbColor, style = {}, verti
     return Math.min(Math.max(v, 0), max);
   };
 
-  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),

--- a/src/components/HueSlider.tsx
+++ b/src/components/HueSlider.tsx
@@ -52,9 +52,13 @@ export function HueSlider({ thumbShape, thumbSize, thumbColor, style = {}, verti
     };
   }, [thumbSize, vertical, reverse]);
 
-  const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
+  const clamp = (v: number, max: number) => {
+    'worklet';
+    return Math.min(Math.max(v, 0), max);
+  };
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+    'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
       percentX = posX / width.value,

--- a/src/components/HueSlider.tsx
+++ b/src/components/HueSlider.tsx
@@ -67,6 +67,8 @@ export function HueSlider({ thumbShape, thumbSize, thumbColor, style = {}, verti
       valY = reverse ? 100 - Math.round(percentY * 100) : Math.round(percentY * 100);
 
     hueValue.value = vertical ? valY : valX;
+
+    runOnJS(onGestureChange)();
   }
 
   const gestureEvent = useAnimatedGestureHandler(
@@ -77,7 +79,6 @@ export function HueSlider({ thumbShape, thumbSize, thumbColor, style = {}, verti
       },
       onActive: (event) => {
         setValueFromGestureEvent(event);
-        runOnJS(onGestureChange)();
       },
       onFinish: () => {
         handleScale.value = withTiming(1, { duration: 100 });

--- a/src/components/HueSlider.tsx
+++ b/src/components/HueSlider.tsx
@@ -85,7 +85,7 @@ export function HueSlider({ thumbShape, thumbSize, thumbColor, style = {}, verti
         runOnJS(onGestureEnd)();
       },
     },
-    [thumbSize, vertical, reverse]
+    [width.value, height.value, vertical, reverse]
   );
 
   const onLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {

--- a/src/components/HueSlider.tsx
+++ b/src/components/HueSlider.tsx
@@ -63,8 +63,8 @@ export function HueSlider({ thumbShape, thumbSize, thumbColor, style = {}, verti
       posY = clamp(event.y, height.value),
       percentX = posX / width.value,
       percentY = posY / height.value,
-      valX = reverse ? 100 - Math.round(percentX * 100) : Math.round(percentX * 100),
-      valY = reverse ? 100 - Math.round(percentY * 100) : Math.round(percentY * 100);
+      valX = reverse ? 360 - Math.round(percentX * 360) : Math.round(percentX * 360),
+      valY = reverse ? 360 - Math.round(percentY * 360) : Math.round(percentY * 360);
 
     hueValue.value = vertical ? valY : valX;
 

--- a/src/components/HueSlider.tsx
+++ b/src/components/HueSlider.tsx
@@ -69,15 +69,15 @@ export function HueSlider({ thumbShape, thumbSize, thumbColor, style = {}, verti
     hueValue.value = vertical ? valY : valX;
 
     runOnJS(onGestureChange)();
-  }
+  };
 
   const gestureEvent = useAnimatedGestureHandler(
     {
-      onStart: (event) => {
+      onStart: event => {
         handleScale.value = withTiming(1.2, { duration: 100 });
         setValueFromGestureEvent(event);
       },
-      onActive: (event) => {
+      onActive: event => {
         setValueFromGestureEvent(event);
       },
       onFinish: () => {

--- a/src/components/OpacitySlider.tsx
+++ b/src/components/OpacitySlider.tsx
@@ -54,9 +54,13 @@ export function OpacitySlider({ thumbShape, thumbSize, thumbColor, style = {}, v
 
   const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, 100%, 50%)` }));
 
-  const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
+  const clamp = (v: number, max: number) => {
+    'worklet';
+    return Math.min(Math.max(v, 0), max);
+  };
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+    'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
       percentX = posX / width.value,

--- a/src/components/OpacitySlider.tsx
+++ b/src/components/OpacitySlider.tsx
@@ -87,7 +87,7 @@ export function OpacitySlider({ thumbShape, thumbSize, thumbColor, style = {}, v
         runOnJS(onGestureEnd)();
       },
     },
-    [thumbSize, vertical, reverse]
+    [width.value, height.value, vertical, reverse]
   );
 
   const onLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {

--- a/src/components/OpacitySlider.tsx
+++ b/src/components/OpacitySlider.tsx
@@ -68,7 +68,7 @@ export function OpacitySlider({ thumbShape, thumbSize, thumbColor, style = {}, v
       valX = reverse ? 100 - Math.round(percentX * 100) : Math.round(percentX * 100),
       valY = reverse ? 100 - Math.round(percentY * 100) : Math.round(percentY * 100);
 
-    alphaValue.value = vertical ? valY : valX;
+    alphaValue.value = (vertical ? valY : valX) / 100;
 
     runOnJS(onGestureChange)();
   }

--- a/src/components/OpacitySlider.tsx
+++ b/src/components/OpacitySlider.tsx
@@ -75,10 +75,10 @@ export function OpacitySlider({ thumbShape, thumbSize, thumbColor, style = {}, v
     {
       onStart: (event) => {
         handleScale.value = withTiming(1.2, { duration: 100 });
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
       },
       onActive: (event) => {
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
         runOnJS(onGestureChange)();
       },
       onFinish: () => {

--- a/src/components/OpacitySlider.tsx
+++ b/src/components/OpacitySlider.tsx
@@ -71,15 +71,15 @@ export function OpacitySlider({ thumbShape, thumbSize, thumbColor, style = {}, v
     alphaValue.value = (vertical ? valY : valX) / 100;
 
     runOnJS(onGestureChange)();
-  }
+  };
 
   const gestureEvent = useAnimatedGestureHandler(
     {
-      onStart: (event) => {
+      onStart: event => {
         handleScale.value = withTiming(1.2, { duration: 100 });
         setValueFromGestureEvent(event);
       },
-      onActive: (event) => {
+      onActive: event => {
         setValueFromGestureEvent(event);
       },
       onFinish: () => {

--- a/src/components/OpacitySlider.tsx
+++ b/src/components/OpacitySlider.tsx
@@ -59,7 +59,7 @@ export function OpacitySlider({ thumbShape, thumbSize, thumbColor, style = {}, v
     return Math.min(Math.max(v, 0), max);
   };
 
-  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),

--- a/src/components/OpacitySlider.tsx
+++ b/src/components/OpacitySlider.tsx
@@ -69,6 +69,8 @@ export function OpacitySlider({ thumbShape, thumbSize, thumbColor, style = {}, v
       valY = reverse ? 100 - Math.round(percentY * 100) : Math.round(percentY * 100);
 
     alphaValue.value = vertical ? valY : valX;
+
+    runOnJS(onGestureChange)();
   }
 
   const gestureEvent = useAnimatedGestureHandler(
@@ -79,7 +81,6 @@ export function OpacitySlider({ thumbShape, thumbSize, thumbColor, style = {}, v
       },
       onActive: (event) => {
         setValueFromGestureEvent(event);
-        runOnJS(onGestureChange)();
       },
       onFinish: () => {
         handleScale.value = withTiming(1, { duration: 100 });

--- a/src/components/Panel1.tsx
+++ b/src/components/Panel1.tsx
@@ -68,10 +68,10 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     {
       onStart: (event) => {
         handleScale.value = withTiming(1.2, { duration: 100 });
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
       },
       onActive: (event) => {
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
         runOnJS(onGestureChange)();
       },
       onFinish: () => {

--- a/src/components/Panel1.tsx
+++ b/src/components/Panel1.tsx
@@ -53,7 +53,7 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     return Math.min(Math.max(v, 0), max);
   };
 
-  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),

--- a/src/components/Panel1.tsx
+++ b/src/components/Panel1.tsx
@@ -62,6 +62,8 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
 
     saturationValue.value = Math.round(percentX * 100);
     brightnessValue.value = Math.round(100 - percentY * 100);
+
+    runOnJS(onGestureChange)();
 }
 
   const gestureEvent = useAnimatedGestureHandler(
@@ -72,7 +74,6 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
       },
       onActive: (event) => {
         setValueFromGestureEvent(event);
-        runOnJS(onGestureChange)();
       },
       onFinish: () => {
         handleScale.value = withTiming(1, { duration: 100 });

--- a/src/components/Panel1.tsx
+++ b/src/components/Panel1.tsx
@@ -66,19 +66,22 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     runOnJS(onGestureChange)();
   };
 
-  const gestureEvent = useAnimatedGestureHandler({
-    onStart: event => {
-      handleScale.value = withTiming(1.2, { duration: 100 });
-      setValueFromGestureEvent(event);
+  const gestureEvent = useAnimatedGestureHandler(
+    {
+      onStart: event => {
+        handleScale.value = withTiming(1.2, { duration: 100 });
+        setValueFromGestureEvent(event);
+      },
+      onActive: event => {
+        setValueFromGestureEvent(event);
+      },
+      onFinish: () => {
+        handleScale.value = withTiming(1, { duration: 100 });
+        runOnJS(onGestureEnd)();
+      },
     },
-    onActive: event => {
-      setValueFromGestureEvent(event);
-    },
-    onFinish: () => {
-      handleScale.value = withTiming(1, { duration: 100 });
-      runOnJS(onGestureEnd)();
-    },
-  });
+    [width.value, height.value]
+  );
 
   const onLayout = useCallback(({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     width.value = Math.round(layout.width);

--- a/src/components/Panel1.tsx
+++ b/src/components/Panel1.tsx
@@ -64,23 +64,21 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     brightnessValue.value = Math.round(100 - percentY * 100);
 
     runOnJS(onGestureChange)();
-}
+  };
 
-  const gestureEvent = useAnimatedGestureHandler(
-    {
-      onStart: (event) => {
-        handleScale.value = withTiming(1.2, { duration: 100 });
-        setValueFromGestureEvent(event);
-      },
-      onActive: (event) => {
-        setValueFromGestureEvent(event);
-      },
-      onFinish: () => {
-        handleScale.value = withTiming(1, { duration: 100 });
-        runOnJS(onGestureEnd)();
-      },
+  const gestureEvent = useAnimatedGestureHandler({
+    onStart: event => {
+      handleScale.value = withTiming(1.2, { duration: 100 });
+      setValueFromGestureEvent(event);
     },
-  );
+    onActive: event => {
+      setValueFromGestureEvent(event);
+    },
+    onFinish: () => {
+      handleScale.value = withTiming(1, { duration: 100 });
+      runOnJS(onGestureEnd)();
+    },
+  });
 
   const onLayout = useCallback(({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     width.value = Math.round(layout.width);

--- a/src/components/Panel1.tsx
+++ b/src/components/Panel1.tsx
@@ -13,6 +13,7 @@ import Thumb from './Thumbs';
 
 import type { LayoutChangeEvent } from 'react-native';
 import type { PanelProps } from '../types';
+import { PanGestureHandlerEventPayload } from 'react-native-gesture-handler';
 
 export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelProps) {
   const {
@@ -47,32 +48,34 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
 
   const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, 100%, 50%)` }));
 
-  const gestureEvent = useAnimatedGestureHandler({
-    onStart: (event, ctx: { x: number; y: number }) => {
-      ctx.x = event.x;
-      ctx.y = event.y;
-      handleScale.value = withTiming(1.2, { duration: 100 });
-    },
-    onActive: (event, ctx) => {
-      const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
+  const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
 
-      const x = event.x,
-          y = event.y,
-          posX = clamp(x, width.value),
-          posY = clamp(y, height.value),
-        percentX = posX / width.value,
-        percentY = posY / height.value;
+  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+    const posX = clamp(event.x, width.value),
+      posY = clamp(event.y, height.value),
+      percentX = posX / width.value,
+      percentY = posY / height.value;
 
-      saturationValue.value = Math.round(percentX * 100);
-      brightnessValue.value = Math.round(100 - percentY * 100);
+    saturationValue.value = Math.round(percentX * 100);
+    brightnessValue.value = Math.round(100 - percentY * 100);
+}
 
-      runOnJS(onGestureChange)();
+  const gestureEvent = useAnimatedGestureHandler(
+    {
+      onStart: (event) => {
+        handleScale.value = withTiming(1.2, { duration: 100 });
+        runOnJS(setValueFromGestureEvent)(event);
+      },
+      onActive: (event) => {
+        runOnJS(setValueFromGestureEvent)(event);
+        runOnJS(onGestureChange)();
+      },
+      onFinish: () => {
+        handleScale.value = withTiming(1, { duration: 100 });
+        runOnJS(onGestureEnd)();
+      },
     },
-    onFinish: () => {
-      handleScale.value = withTiming(1, { duration: 100 });
-      runOnJS(onGestureEnd)();
-    },
-  });
+  );
 
   const onLayout = useCallback(({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     width.value = Math.round(layout.width);

--- a/src/components/Panel1.tsx
+++ b/src/components/Panel1.tsx
@@ -48,9 +48,13 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
 
   const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, 100%, 50%)` }));
 
-  const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
+  const clamp = (v: number, max: number) => {
+    'worklet';
+    return Math.min(Math.max(v, 0), max);
+  };
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+    'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
       percentX = posX / width.value,

--- a/src/components/Panel2.tsx
+++ b/src/components/Panel2.tsx
@@ -1,4 +1,4 @@
-import React, {  useContext, useCallback } from 'react';
+import React, { useContext, useCallback } from 'react';
 import { ImageBackground } from 'react-native';
 import { PanGestureHandler } from 'react-native-gesture-handler';
 import Animated, {
@@ -31,7 +31,6 @@ export function Panel2({ thumbShape, thumbSize, thumbColor, reverse = false, sty
   const borderRadius = getStyle(style, 'borderRadius') ?? 5;
   const getHeight = getStyle(style, 'height') ?? 200;
 
-
   const width = useSharedValue(0);
   const height = useSharedValue(0);
 
@@ -61,27 +60,25 @@ export function Panel2({ thumbShape, thumbSize, thumbColor, reverse = false, sty
     saturationValue.value = Math.round(100 - percentY * 100);
 
     runOnJS(onGestureChange)();
-  }
+  };
 
-  const gestureEvent = useAnimatedGestureHandler(
-    {
-      onStart: (event) => {
-        handleScale.value = withTiming(1.2, { duration: 100 });
-        setValueFromGestureEvent(event);
-      },
-      onActive: (event) => {
-        setValueFromGestureEvent(event);
-      },
-      onFinish: () => {
-        handleScale.value = withTiming(1, { duration: 100 });
-        runOnJS(onGestureEnd)();
-      },
+  const gestureEvent = useAnimatedGestureHandler({
+    onStart: event => {
+      handleScale.value = withTiming(1.2, { duration: 100 });
+      setValueFromGestureEvent(event);
     },
-  );
+    onActive: event => {
+      setValueFromGestureEvent(event);
+    },
+    onFinish: () => {
+      handleScale.value = withTiming(1, { duration: 100 });
+      runOnJS(onGestureEnd)();
+    },
+  });
 
   const onLayout = useCallback(({ nativeEvent: { layout } }: LayoutChangeEvent) => {
-    width.value = (Math.round(layout.width));
-    height.value = (Math.round(layout.height));
+    width.value = Math.round(layout.width);
+    height.value = Math.round(layout.height);
   }, []);
 
   return (

--- a/src/components/Panel2.tsx
+++ b/src/components/Panel2.tsx
@@ -65,10 +65,10 @@ export function Panel2({ thumbShape, thumbSize, thumbColor, reverse = false, sty
     {
       onStart: (event) => {
         handleScale.value = withTiming(1.2, { duration: 100 });
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
       },
       onActive: (event) => {
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
         runOnJS(onGestureChange)();
       },
       onFinish: () => {

--- a/src/components/Panel2.tsx
+++ b/src/components/Panel2.tsx
@@ -62,19 +62,22 @@ export function Panel2({ thumbShape, thumbSize, thumbColor, reverse = false, sty
     runOnJS(onGestureChange)();
   };
 
-  const gestureEvent = useAnimatedGestureHandler({
-    onStart: event => {
-      handleScale.value = withTiming(1.2, { duration: 100 });
-      setValueFromGestureEvent(event);
+  const gestureEvent = useAnimatedGestureHandler(
+    {
+      onStart: event => {
+        handleScale.value = withTiming(1.2, { duration: 100 });
+        setValueFromGestureEvent(event);
+      },
+      onActive: event => {
+        setValueFromGestureEvent(event);
+      },
+      onFinish: () => {
+        handleScale.value = withTiming(1, { duration: 100 });
+        runOnJS(onGestureEnd)();
+      },
     },
-    onActive: event => {
-      setValueFromGestureEvent(event);
-    },
-    onFinish: () => {
-      handleScale.value = withTiming(1, { duration: 100 });
-      runOnJS(onGestureEnd)();
-    },
-  });
+    [width.value, height.value, reverse]
+  );
 
   const onLayout = useCallback(({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     width.value = Math.round(layout.width);

--- a/src/components/Panel2.tsx
+++ b/src/components/Panel2.tsx
@@ -45,9 +45,13 @@ export function Panel2({ thumbShape, thumbSize, thumbColor, reverse = false, sty
     return { transform: [{ translateX: posX }, { translateY: posY }, { scale: handleScale.value }] };
   }, [thumbSize, reverse]);
 
-  const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
+  const clamp = (v: number, max: number) => {
+    'worklet';
+    return Math.min(Math.max(v, 0), max);
+  };
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+    'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
       percentX = posX / width.value,

--- a/src/components/Panel2.tsx
+++ b/src/components/Panel2.tsx
@@ -50,7 +50,7 @@ export function Panel2({ thumbShape, thumbSize, thumbColor, reverse = false, sty
     return Math.min(Math.max(v, 0), max);
   };
 
-  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),

--- a/src/components/Panel2.tsx
+++ b/src/components/Panel2.tsx
@@ -59,6 +59,8 @@ export function Panel2({ thumbShape, thumbSize, thumbColor, reverse = false, sty
 
     hueValue.value = reverse ? 360 - Math.round(percentX * 360) : Math.round(percentX * 360);
     saturationValue.value = Math.round(100 - percentY * 100);
+
+    runOnJS(onGestureChange)();
   }
 
   const gestureEvent = useAnimatedGestureHandler(
@@ -69,7 +71,6 @@ export function Panel2({ thumbShape, thumbSize, thumbColor, reverse = false, sty
       },
       onActive: (event) => {
         setValueFromGestureEvent(event);
-        runOnJS(onGestureChange)();
       },
       onFinish: () => {
         handleScale.value = withTiming(1, { duration: 100 });

--- a/src/components/Panel3.tsx
+++ b/src/components/Panel3.tsx
@@ -63,23 +63,21 @@ export function Panel3({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     saturationValue.value = Math.round(radiusPercent * 100);
 
     runOnJS(onGestureChange)();
-  }
+  };
 
-  const gestureEvent = useAnimatedGestureHandler(
-    {
-      onStart: (event) => {
-        handleScale.value = withTiming(1.2, { duration: 100 });
-        setValueFromGestureEvent(event);
-      },
-      onActive: (event) => {
-        setValueFromGestureEvent(event);
-      },
-      onFinish: () => {
-        handleScale.value = withTiming(1, { duration: 100 });
-        runOnJS(onGestureEnd)();
-      },
+  const gestureEvent = useAnimatedGestureHandler({
+    onStart: event => {
+      handleScale.value = withTiming(1.2, { duration: 100 });
+      setValueFromGestureEvent(event);
     },
-  );
+    onActive: event => {
+      setValueFromGestureEvent(event);
+    },
+    onFinish: () => {
+      handleScale.value = withTiming(1, { duration: 100 });
+      runOnJS(onGestureEnd)();
+    },
+  });
 
   const onLayout = useCallback(({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     const layoutWidth = Math.round(layout.width);

--- a/src/components/Panel3.tsx
+++ b/src/components/Panel3.tsx
@@ -65,19 +65,22 @@ export function Panel3({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     runOnJS(onGestureChange)();
   };
 
-  const gestureEvent = useAnimatedGestureHandler({
-    onStart: event => {
-      handleScale.value = withTiming(1.2, { duration: 100 });
-      setValueFromGestureEvent(event);
+  const gestureEvent = useAnimatedGestureHandler(
+    {
+      onStart: event => {
+        handleScale.value = withTiming(1.2, { duration: 100 });
+        setValueFromGestureEvent(event);
+      },
+      onActive: event => {
+        setValueFromGestureEvent(event);
+      },
+      onFinish: () => {
+        handleScale.value = withTiming(1, { duration: 100 });
+        runOnJS(onGestureEnd)();
+      },
     },
-    onActive: event => {
-      setValueFromGestureEvent(event);
-    },
-    onFinish: () => {
-      handleScale.value = withTiming(1, { duration: 100 });
-      runOnJS(onGestureEnd)();
-    },
-  });
+    [width.value]
+  );
 
   const onLayout = useCallback(({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     const layoutWidth = Math.round(layout.width);

--- a/src/components/Panel3.tsx
+++ b/src/components/Panel3.tsx
@@ -44,9 +44,13 @@ export function Panel3({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     };
   }, [thumbSize]);
 
-  const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
+  const clamp = (v: number, max: number) => {
+    'worklet';
+    return Math.min(Math.max(v, 0), max);
+  };
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+    'worklet';
     const center = width.value / 2,
       dx = center - event.x,
       dy = center - event.y,

--- a/src/components/Panel3.tsx
+++ b/src/components/Panel3.tsx
@@ -67,10 +67,10 @@ export function Panel3({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     {
       onStart: (event) => {
         handleScale.value = withTiming(1.2, { duration: 100 });
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
       },
       onActive: (event) => {
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
         runOnJS(onGestureChange)();
       },
       onFinish: () => {

--- a/src/components/Panel3.tsx
+++ b/src/components/Panel3.tsx
@@ -61,6 +61,8 @@ export function Panel3({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
 
     hueValue.value = Math.round(angle);
     saturationValue.value = Math.round(radiusPercent * 100);
+
+    runOnJS(onGestureChange)();
   }
 
   const gestureEvent = useAnimatedGestureHandler(
@@ -71,7 +73,6 @@ export function Panel3({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
       },
       onActive: (event) => {
         setValueFromGestureEvent(event);
-        runOnJS(onGestureChange)();
       },
       onFinish: () => {
         handleScale.value = withTiming(1, { duration: 100 });

--- a/src/components/Panel3.tsx
+++ b/src/components/Panel3.tsx
@@ -49,7 +49,7 @@ export function Panel3({ thumbShape, thumbSize, thumbColor, style = {} }: PanelP
     return Math.min(Math.max(v, 0), max);
   };
 
-  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const center = width.value / 2,
       dx = center - event.x,

--- a/src/components/SaturationSlider.tsx
+++ b/src/components/SaturationSlider.tsx
@@ -77,6 +77,8 @@ export function SaturationSlider({
       valY = reverse ? 100 - Math.round(percentY * 100) : Math.round(percentY * 100);
 
     saturationValue.value = vertical ? valY : valX;
+
+    runOnJS(onGestureChange)();
   }
 
   const gestureEvent = useAnimatedGestureHandler(
@@ -87,7 +89,6 @@ export function SaturationSlider({
       },
       onActive: (event) => {
         setValueFromGestureEvent(event);
-        runOnJS(onGestureChange)();
       },
       onFinish: () => {
         handleScale.value = withTiming(1, { duration: 100 });

--- a/src/components/SaturationSlider.tsx
+++ b/src/components/SaturationSlider.tsx
@@ -62,9 +62,13 @@ export function SaturationSlider({
 
   const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, 100%, 50%)` }));
 
-  const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
+  const clamp = (v: number, max: number) => {
+    'worklet';
+    return Math.min(Math.max(v, 0), max);
+  };
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+    'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
       percentX = posX / width.value,

--- a/src/components/SaturationSlider.tsx
+++ b/src/components/SaturationSlider.tsx
@@ -67,7 +67,7 @@ export function SaturationSlider({
     return Math.min(Math.max(v, 0), max);
   };
 
-  function setValueFromGestureEvent(event: PanGestureHandlerEventPayload) {
+  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),

--- a/src/components/SaturationSlider.tsx
+++ b/src/components/SaturationSlider.tsx
@@ -79,15 +79,15 @@ export function SaturationSlider({
     saturationValue.value = vertical ? valY : valX;
 
     runOnJS(onGestureChange)();
-  }
+  };
 
   const gestureEvent = useAnimatedGestureHandler(
     {
-      onStart: (event) => {
+      onStart: event => {
         handleScale.value = withTiming(1.2, { duration: 100 });
         setValueFromGestureEvent(event);
       },
-      onActive: (event) => {
+      onActive: event => {
         setValueFromGestureEvent(event);
       },
       onFinish: () => {

--- a/src/components/SaturationSlider.tsx
+++ b/src/components/SaturationSlider.tsx
@@ -83,10 +83,10 @@ export function SaturationSlider({
     {
       onStart: (event) => {
         handleScale.value = withTiming(1.2, { duration: 100 });
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
       },
       onActive: (event) => {
-        runOnJS(setValueFromGestureEvent)(event);
+        setValueFromGestureEvent(event);
         runOnJS(onGestureChange)();
       },
       onFinish: () => {

--- a/src/components/SaturationSlider.tsx
+++ b/src/components/SaturationSlider.tsx
@@ -95,7 +95,7 @@ export function SaturationSlider({
         runOnJS(onGestureEnd)();
       },
     },
-    [thumbSize, vertical, reverse]
+    [width.value, height.value, vertical, reverse]
   );
 
   const onLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {

--- a/src/components/SaturationSlider.tsx
+++ b/src/components/SaturationSlider.tsx
@@ -12,7 +12,8 @@ import { CTX, getStyle } from '../GlobalStyles';
 import Thumb from './Thumbs';
 
 import type { LayoutChangeEvent } from 'react-native';
-import type { SliderPorps } from '../types';
+import type { SliderProps } from '../types';
+import { PanGestureHandlerEventPayload } from 'react-native-gesture-handler';
 
 const isRtl = I18nManager.isRTL;
 
@@ -23,7 +24,7 @@ export function SaturationSlider({
   style = {},
   vertical = false,
   reverse = false,
-}: SliderPorps) {
+}: SliderProps) {
   const {
     saturationValue,
     hueValue,
@@ -61,27 +62,27 @@ export function SaturationSlider({
 
   const activeHueStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, 100%, 50%)` }));
 
+  const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
+
+  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+    const posX = clamp(event.x, width.value),
+      posY = clamp(event.y, height.value),
+      percentX = posX / width.value,
+      percentY = posY / height.value,
+      valX = reverse ? 100 - Math.round(percentX * 100) : Math.round(percentX * 100),
+      valY = reverse ? 100 - Math.round(percentY * 100) : Math.round(percentY * 100);
+
+    saturationValue.value = vertical ? valY : valX;
+  }
+
   const gestureEvent = useAnimatedGestureHandler(
     {
-      onStart: (event, ctx: { x: number; y: number }) => {
-        ctx.x = event.x;
-        ctx.y = event.y;
+      onStart: (event) => {
         handleScale.value = withTiming(1.2, { duration: 100 });
+        runOnJS(setValueFromGestureEvent)(event);
       },
-      onActive: (event, ctx) => {
-        const clamp = (v: number, max: number) => Math.min(Math.max(v, 0), max);
-
-        const x = event.x,
-          y = event.y,
-          posX = clamp(x, width.value),
-          posY = clamp(y, height.value),
-          percentX = posX / width.value,
-          percentY = posY / height.value,
-          saturationX = reverse ? 100 - Math.round(percentX * 100) : Math.round(percentX * 100),
-          saturationY = reverse ? 100 - Math.round(percentY * 100) : Math.round(percentY * 100);
-
-        saturationValue.value = vertical ? saturationY : saturationX;
-
+      onActive: (event) => {
+        runOnJS(setValueFromGestureEvent)(event);
         runOnJS(onGestureChange)();
       },
       onFinish: () => {

--- a/src/components/Swatches.tsx
+++ b/src/components/Swatches.tsx
@@ -24,7 +24,6 @@ const SWATCHES_COLORS = [
   '#607D8B',
 ];
 
-
 import type { SwatchesPorps } from '../types';
 
 export function Swatches({ colors = SWATCHES_COLORS, style = {}, swatchStyle = {} }: SwatchesPorps) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,7 +165,7 @@ export interface Panel2Props extends PanelProps {
   reverse?: boolean;
 }
 
-export interface SliderPorps {
+export interface SliderProps {
   /** - slider's handle (thumb) size (height*width). */
   thumbSize?: number;
 


### PR DESCRIPTION
This PR refactors the color logic out of `onActive` so it can also be applied in `onStart`. As a result, Android and iOS thumbs can have their position updated by tapping instead of having to tap and then drag before the values update.

https://user-images.githubusercontent.com/16565387/222799629-3c7255ac-893e-4cba-97dd-6f66caa5e049.mov

