### PR TITLE
Migrating to RNGH `react-native-gesture-handler` v2 and Enabling the new Web Implementation by default

### DIFF
--- a/docusaurus/docs/API/ColorPicker.md
+++ b/docusaurus/docs/API/ColorPicker.md
@@ -167,9 +167,3 @@ function MyCustomThumb({
 - The passed color object has the following properties: `hex`, `rgb`, `rgba`, `hsv`, `hsva`, `hwb`, `hwba`, `hsl`, and `hsla`
 - `type: (color: object) => void`
 - `default: null`
-
-:::caution
-
-As of `react-native-gesture-handler@2.9.0` the new web implementation does not support the events which trigger this callback.
-
-:::

--- a/src/ColorPicker.tsx
+++ b/src/ColorPicker.tsx
@@ -8,6 +8,13 @@ import colorKit from './colorKit';
 import type { AnyFormat } from './colorKit';
 import type { ColorPickerProps, TCTX } from './types';
 
+try {
+  const { enableExperimentalWebImplementation } = require('react-native-gesture-handler');
+  enableExperimentalWebImplementation(true);
+} catch (error) {
+  // ignore
+}
+
 export const CTX = createContext<TCTX>(null!);
 
 export default function ColorPicker({

--- a/src/components/BrightnessSlider.tsx
+++ b/src/components/BrightnessSlider.tsx
@@ -1,13 +1,7 @@
 import React, { useContext } from 'react';
 import { I18nManager } from 'react-native';
-import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  useAnimatedGestureHandler,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import Thumb from './Thumb/Thumb';
 import { CTX } from '../ColorPicker';
@@ -77,7 +71,7 @@ export function BrightnessSlider({
     backgroundColor: hsva2Hsla(hueValue.value, adaptSpectrum ? saturationValue.value : 100, 100),
   }));
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  const onGestureUpdate = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
@@ -90,23 +84,21 @@ export function BrightnessSlider({
 
     runOnJS(onGestureChange)();
   };
+  const onGestureBegin = (event: PanGestureHandlerEventPayload) => {
+    'worklet';
+    handleScale.value = withTiming(1.2, { duration: 100 });
+    onGestureUpdate(event);
+  };
+  const onGestureFinish = () => {
+    'worklet';
+    handleScale.value = withTiming(1, { duration: 100 });
+    runOnJS(onGestureEnd)();
+  };
 
-  const gestureEvent = useAnimatedGestureHandler(
-    {
-      onStart: event => {
-        handleScale.value = withTiming(1.2, { duration: 100 });
-        setValueFromGestureEvent(event);
-      },
-      onActive: event => {
-        setValueFromGestureEvent(event);
-      },
-      onFinish: () => {
-        handleScale.value = withTiming(1, { duration: 100 });
-        runOnJS(onGestureEnd)();
-      },
-    },
-    [width.value, height.value, vertical, reverse]
-  );
+  const pan = Gesture.Pan().onBegin(onGestureBegin).onUpdate(onGestureUpdate).onEnd(onGestureFinish);
+  const tap = Gesture.Tap().onTouchesUp(onGestureFinish);
+  const longPress = Gesture.LongPress().onTouchesUp(onGestureFinish);
+  const composed = Gesture.Exclusive(pan, tap, longPress);
 
   const onLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     if (!vertical) width.value = withTiming(Math.round(layout.width), { duration: 5 });
@@ -132,7 +124,7 @@ export function BrightnessSlider({
   const thicknessStyle = vertical ? { width: sliderThickness } : { height: sliderThickness };
 
   return (
-    <PanGestureHandler onGestureEvent={gestureEvent} minDist={0}>
+    <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
         style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
@@ -153,6 +145,6 @@ export function BrightnessSlider({
           }}
         />
       </Animated.View>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }

--- a/src/components/HueSlider.tsx
+++ b/src/components/HueSlider.tsx
@@ -1,13 +1,7 @@
 import React, { useContext } from 'react';
 import { I18nManager, StyleSheet } from 'react-native';
-import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  useAnimatedGestureHandler,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import Thumb from './Thumb/Thumb';
 import { CTX } from '../ColorPicker';
@@ -80,7 +74,7 @@ export function HueSlider({
     backgroundColor: hsva2Hsla(0, 0, 0, 1 - brightnessValue.value / 100),
   }));
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  const onGestureUpdate = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
@@ -93,23 +87,21 @@ export function HueSlider({
 
     runOnJS(onGestureChange)();
   };
+  const onGestureBegin = (event: PanGestureHandlerEventPayload) => {
+    'worklet';
+    handleScale.value = withTiming(1.2, { duration: 100 });
+    onGestureUpdate(event);
+  };
+  const onGestureFinish = () => {
+    'worklet';
+    handleScale.value = withTiming(1, { duration: 100 });
+    runOnJS(onGestureEnd)();
+  };
 
-  const gestureEvent = useAnimatedGestureHandler(
-    {
-      onStart: event => {
-        handleScale.value = withTiming(1.2, { duration: 100 });
-        setValueFromGestureEvent(event);
-      },
-      onActive: event => {
-        setValueFromGestureEvent(event);
-      },
-      onFinish: () => {
-        handleScale.value = withTiming(1, { duration: 100 });
-        runOnJS(onGestureEnd)();
-      },
-    },
-    [width.value, height.value, vertical, reverse]
-  );
+  const pan = Gesture.Pan().onBegin(onGestureBegin).onUpdate(onGestureUpdate).onEnd(onGestureFinish);
+  const tap = Gesture.Tap().onTouchesUp(onGestureFinish);
+  const longPress = Gesture.LongPress().onTouchesUp(onGestureFinish);
+  const composed = Gesture.Exclusive(pan, tap, longPress);
 
   const onLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     if (!vertical) width.value = withTiming(Math.round(layout.width), { duration: 5 });
@@ -135,7 +127,7 @@ export function HueSlider({
   const thicknessStyle = vertical ? { width: sliderThickness } : { height: sliderThickness };
 
   return (
-    <PanGestureHandler onGestureEvent={gestureEvent} minDist={0}>
+    <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
         style={[{ borderRadius }, style, thicknessStyle, { position: 'relative', borderWidth: 0, padding: 0 }]}
@@ -162,6 +154,6 @@ export function HueSlider({
           }}
         />
       </Animated.View>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }

--- a/src/components/Panel1.tsx
+++ b/src/components/Panel1.tsx
@@ -1,13 +1,7 @@
 import React, { useContext, useCallback } from 'react';
 import { ImageBackground } from 'react-native';
-import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  useAnimatedGestureHandler,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import Thumb from './Thumb/Thumb';
 import { CTX } from '../ColorPicker';
@@ -57,7 +51,7 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, renderThumb, thumbSt
 
   const activeColorStyle = useAnimatedStyle(() => ({ backgroundColor: `hsl(${hueValue.value}, 100%, 50%)` }));
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  const onGestureUpdate = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
@@ -69,23 +63,21 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, renderThumb, thumbSt
 
     runOnJS(onGestureChange)();
   };
+  const onGestureBegin = (event: PanGestureHandlerEventPayload) => {
+    'worklet';
+    handleScale.value = withTiming(1.2, { duration: 100 });
+    onGestureUpdate(event);
+  };
+  const onGestureFinish = () => {
+    'worklet';
+    handleScale.value = withTiming(1, { duration: 100 });
+    runOnJS(onGestureEnd)();
+  };
 
-  const gestureEvent = useAnimatedGestureHandler(
-    {
-      onStart: event => {
-        handleScale.value = withTiming(1.2, { duration: 100 });
-        setValueFromGestureEvent(event);
-      },
-      onActive: event => {
-        setValueFromGestureEvent(event);
-      },
-      onFinish: () => {
-        handleScale.value = withTiming(1, { duration: 100 });
-        runOnJS(onGestureEnd)();
-      },
-    },
-    [width.value, height.value]
-  );
+  const pan = Gesture.Pan().onBegin(onGestureBegin).onUpdate(onGestureUpdate).onEnd(onGestureFinish);
+  const tap = Gesture.Tap().onTouchesUp(onGestureFinish);
+  const longPress = Gesture.LongPress().onTouchesUp(onGestureFinish);
+  const composed = Gesture.Exclusive(pan, tap, longPress);
 
   const onLayout = useCallback(({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     width.value = Math.round(layout.width);
@@ -93,7 +85,7 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, renderThumb, thumbSt
   }, []);
 
   return (
-    <PanGestureHandler onGestureEvent={gestureEvent} minDist={0}>
+    <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
         style={[
@@ -121,6 +113,6 @@ export function Panel1({ thumbShape, thumbSize, thumbColor, renderThumb, thumbSt
           }}
         />
       </Animated.View>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }

--- a/src/components/Panel2.tsx
+++ b/src/components/Panel2.tsx
@@ -1,13 +1,7 @@
 import React, { useContext, useCallback } from 'react';
 import { ImageBackground } from 'react-native';
-import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  useAnimatedGestureHandler,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import Thumb from './Thumb/Thumb';
 import { clamp, getStyle } from '../utils';
@@ -62,7 +56,7 @@ export function Panel2({
     return { transform: [{ translateX: posX }, { translateY: posY }, { scale: handleScale.value }] };
   }, [thumbSize, reverse]);
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  const onGestureUpdate = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
@@ -74,23 +68,21 @@ export function Panel2({
 
     runOnJS(onGestureChange)();
   };
+  const onGestureBegin = (event: PanGestureHandlerEventPayload) => {
+    'worklet';
+    handleScale.value = withTiming(1.2, { duration: 100 });
+    onGestureUpdate(event);
+  };
+  const onGestureFinish = () => {
+    'worklet';
+    handleScale.value = withTiming(1, { duration: 100 });
+    runOnJS(onGestureEnd)();
+  };
 
-  const gestureEvent = useAnimatedGestureHandler(
-    {
-      onStart: event => {
-        handleScale.value = withTiming(1.2, { duration: 100 });
-        setValueFromGestureEvent(event);
-      },
-      onActive: event => {
-        setValueFromGestureEvent(event);
-      },
-      onFinish: () => {
-        handleScale.value = withTiming(1, { duration: 100 });
-        runOnJS(onGestureEnd)();
-      },
-    },
-    [width.value, height.value, reverse]
-  );
+  const pan = Gesture.Pan().onBegin(onGestureBegin).onUpdate(onGestureUpdate).onEnd(onGestureFinish);
+  const tap = Gesture.Tap().onTouchesUp(onGestureFinish);
+  const longPress = Gesture.LongPress().onTouchesUp(onGestureFinish);
+  const composed = Gesture.Exclusive(pan, tap, longPress);
 
   const onLayout = useCallback(({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     width.value = Math.round(layout.width);
@@ -98,7 +90,7 @@ export function Panel2({
   }, []);
 
   return (
-    <PanGestureHandler onGestureEvent={gestureEvent} minDist={0}>
+    <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
         style={[styles.panel_container, { height: getHeight }, style, { position: 'relative', borderWidth: 0, padding: 0 }]}
@@ -121,6 +113,6 @@ export function Panel2({
           }}
         />
       </Animated.View>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }

--- a/src/components/SaturationSlider.tsx
+++ b/src/components/SaturationSlider.tsx
@@ -1,13 +1,7 @@
 import React, { useContext } from 'react';
 import { I18nManager, StyleSheet } from 'react-native';
-import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  useAnimatedGestureHandler,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import Thumb from './Thumb/Thumb';
 import { CTX } from '../ColorPicker';
@@ -81,7 +75,7 @@ export function SaturationSlider({
     backgroundColor: hsva2Hsla(0, 0, 0, 1 - brightnessValue.value / 100),
   }));
 
-  const setValueFromGestureEvent = (event: PanGestureHandlerEventPayload) => {
+  const onGestureUpdate = (event: PanGestureHandlerEventPayload) => {
     'worklet';
     const posX = clamp(event.x, width.value),
       posY = clamp(event.y, height.value),
@@ -94,23 +88,21 @@ export function SaturationSlider({
 
     runOnJS(onGestureChange)();
   };
+  const onGestureBegin = (event: PanGestureHandlerEventPayload) => {
+    'worklet';
+    handleScale.value = withTiming(1.2, { duration: 100 });
+    onGestureUpdate(event);
+  };
+  const onGestureFinish = () => {
+    'worklet';
+    handleScale.value = withTiming(1, { duration: 100 });
+    runOnJS(onGestureEnd)();
+  };
 
-  const gestureEvent = useAnimatedGestureHandler(
-    {
-      onStart: event => {
-        handleScale.value = withTiming(1.2, { duration: 100 });
-        setValueFromGestureEvent(event);
-      },
-      onActive: event => {
-        setValueFromGestureEvent(event);
-      },
-      onFinish: () => {
-        handleScale.value = withTiming(1, { duration: 100 });
-        runOnJS(onGestureEnd)();
-      },
-    },
-    [width.value, height.value, vertical, reverse]
-  );
+  const pan = Gesture.Pan().onBegin(onGestureBegin).onUpdate(onGestureUpdate).onEnd(onGestureFinish);
+  const tap = Gesture.Tap().onTouchesUp(onGestureFinish);
+  const longPress = Gesture.LongPress().onTouchesUp(onGestureFinish);
+  const composed = Gesture.Exclusive(pan, tap, longPress);
 
   const onLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
     if (!vertical) width.value = withTiming(Math.round(layout.width), { duration: 5 });
@@ -136,7 +128,7 @@ export function SaturationSlider({
   const thicknessStyle = vertical ? { width: sliderThickness } : { height: sliderThickness };
 
   return (
-    <PanGestureHandler onGestureEvent={gestureEvent} minDist={0}>
+    <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
         style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
@@ -158,6 +150,6 @@ export function SaturationSlider({
           }}
         />
       </Animated.View>
-    </PanGestureHandler>
+    </GestureDetector>
   );
 }


### PR DESCRIPTION
This PR migrates the project to React Native Gesture Handler version 2, replacing the old gesture detection methods with the new API. Additionally, it enables the new Web Implementation by default for version 2.6.0 and higher, allowing tap to slide functionality on the Web platform. This update compatibility across platforms.