### PR TITLE
Add `sliderThickness` prop for individual sliders

### DIFF
--- a/Example/Example1.tsx
+++ b/Example/Example1.tsx
@@ -5,12 +5,12 @@ import ColorPicker, { Panel1, Swatches, Preview, OpacitySlider, HueSlider, Input
 
 const customSwatches = ['#001219', '#005f73', '#0a9396', '#94d2bd', '#e9d8a6'];
 
-interface porpsType {
+interface propsType {
   color: SharedValue<string>;
   onSelectColor: (param: { hex: string }) => void;
 }
 
-export default function Example1({ onSelectColor, color }: porpsType) {
+export default function Example1({ onSelectColor, color }: propsType) {
   const [showModal, setShowModal] = useState(false);
 
   return (

--- a/Example/Example2.tsx
+++ b/Example/Example2.tsx
@@ -5,12 +5,12 @@ import ColorPicker, { Panel3, Swatches, Preview, OpacitySlider, BrightnessSlider
 
 const customSwatches = ['#8a00d4', '#d527b7', '#f782c2', '#f9c46b', '#e3e3e3'];
 
-interface porpsType {
+interface propsType {
   color: SharedValue<string>;
   onSelectColor: (param: { hex: string }) => void;
 }
 
-export default function Example1({ onSelectColor, color }: porpsType) {
+export default function Example1({ onSelectColor, color }: propsType) {
   const [showModal, setShowModal] = useState(false);
 
   return (

--- a/Example/Example3.tsx
+++ b/Example/Example3.tsx
@@ -6,7 +6,7 @@ import type { PreviewTextProps } from 'reanimated-color-picker';
 
 const customSwatches = ['#f72585', '#b5179e', '#7209b7', '#560bad', '#480ca8'];
 
-interface porpsType {
+interface propsType {
   color: SharedValue<string>;
   onSelectColor: (param: { hex: string }) => void;
 }
@@ -37,7 +37,7 @@ function FormatsTabs() {
   );
 }
 
-export default function Example3({ onSelectColor, color }: porpsType) {
+export default function Example3({ onSelectColor, color }: propsType) {
   const [showModal, setShowModal] = useState(false);
 
   return (

--- a/Example/Example4.tsx
+++ b/Example/Example4.tsx
@@ -6,12 +6,12 @@ import ColorPicker, { Swatches, Preview, OpacitySlider, BrightnessSlider, HueSli
 const customSwatches = ['#ffbe0b', '#fb5607', '#ff006e', '#8338ec', '#3a86ff'];
 const isRTL = I18nManager.isRTL;
 
-interface porpsType {
+interface propsType {
   color: SharedValue<string>;
   onSelectColor: (param: { hex: string }) => void;
 }
 
-export default function Example4({ onSelectColor, color }: porpsType) {
+export default function Example4({ onSelectColor, color }: propsType) {
   const [showModal, setShowModal] = useState(false);
 
   return (

--- a/docusaurus/docs/API/_slidersProps.mdx
+++ b/docusaurus/docs/API/_slidersProps.mdx
@@ -18,6 +18,12 @@
 
 :::
 
+### `sliderThickness`
+
+- The thickness is the `width` of the slider in `vertical` mode or the `height` in `horizontal` mode.
+- `type: number`
+- `default: 25`
+
 ### `thumbShape`
 
 - The shape and appearance of the slider's thumb.

--- a/src/components/Sliders/BrightnessSlider.tsx
+++ b/src/components/Sliders/BrightnessSlider.tsx
@@ -21,6 +21,7 @@ export function BrightnessSlider({
   renderThumb: localRenderThumb,
   thumbStyle: localThumbStyle,
   thumbInnerStyle: localThumbInnerStyle,
+  sliderThickness: localSliderThickness,
   style = {},
   vertical = false,
   reverse = false,
@@ -31,13 +32,13 @@ export function BrightnessSlider({
     saturationValue,
     onGestureChange,
     onGestureEnd,
-    sliderThickness,
     thumbSize: globalThumbSize,
     thumbShape: globalThumbShape,
     thumbColor: globalThumbColor,
     renderThumb: globalRenderThumb,
     thumbStyle: globalThumbStyle,
     thumbInnerStyle: globalThumbInnerStyle,
+    sliderThickness: globalSliderThickness,
   } = useContext(CTX);
 
   const thumbShape = localThumbShape ?? globalThumbShape,
@@ -45,7 +46,8 @@ export function BrightnessSlider({
     thumbColor = localThumbColor ?? globalThumbColor,
     renderThumb = localRenderThumb ?? globalRenderThumb,
     thumbStyle = localThumbStyle ?? globalThumbStyle ?? {},
-    thumbInnerStyle = localThumbInnerStyle ?? globalThumbInnerStyle ?? {};
+    thumbInnerStyle = localThumbInnerStyle ?? globalThumbInnerStyle ?? {},
+    sliderThickness = localSliderThickness ?? globalSliderThickness;
 
   const borderRadius = getStyle(style, 'borderRadius') ?? 5,
     getWidth = getStyle(style, 'width'),

--- a/src/components/Sliders/HueSlider.tsx
+++ b/src/components/Sliders/HueSlider.tsx
@@ -21,6 +21,7 @@ export function HueSlider({
   renderThumb: localRenderThumb,
   thumbInnerStyle: localThumbInnerStyle,
   thumbStyle: localThumbStyle,
+  sliderThickness: localSliderThickness,
   style = {},
   vertical = false,
   reverse = false,
@@ -31,13 +32,13 @@ export function HueSlider({
     brightnessValue,
     hueValue,
     saturationValue,
-    sliderThickness,
     thumbSize: globalThumbSize,
     thumbShape: globalThumbShape,
     thumbColor: globalThumbColor,
     renderThumb: globalRenderThumb,
     thumbStyle: globalThumbStyle,
     thumbInnerStyle: globalThumbInnerStyle,
+    sliderThickness: globalSliderThickness,
   } = useContext(CTX);
 
   const thumbShape = localThumbShape ?? globalThumbShape,
@@ -45,7 +46,8 @@ export function HueSlider({
     thumbColor = localThumbColor ?? globalThumbColor,
     renderThumb = localRenderThumb ?? globalRenderThumb,
     thumbStyle = localThumbStyle ?? globalThumbStyle ?? {},
-    thumbInnerStyle = localThumbInnerStyle ?? globalThumbInnerStyle ?? {};
+    thumbInnerStyle = localThumbInnerStyle ?? globalThumbInnerStyle ?? {},
+    sliderThickness = localSliderThickness ?? globalSliderThickness;
 
   const borderRadius = getStyle(style, 'borderRadius') ?? 5,
     getWidth = getStyle(style, 'width'),

--- a/src/components/Sliders/OpacitySlider.tsx
+++ b/src/components/Sliders/OpacitySlider.tsx
@@ -21,6 +21,7 @@ export function OpacitySlider({
   renderThumb: localRenderThumb,
   thumbStyle: localThumbStyle,
   thumbInnerStyle: localThumbInnerStyle,
+  sliderThickness: localSliderThickness,
   style = {},
   vertical = false,
   reverse = false,
@@ -32,13 +33,13 @@ export function OpacitySlider({
     saturationValue,
     onGestureChange,
     onGestureEnd,
-    sliderThickness,
     thumbSize: globalThumbsSize,
     thumbShape: globalThumbsShape,
     thumbColor: globalThumbsColor,
     renderThumb: globalRenderThumbs,
     thumbStyle: globalThumbsStyle,
     thumbInnerStyle: globalThumbsInnerStyle,
+    sliderThickness: globalSliderThickness,
   } = useContext(CTX);
 
   const thumbShape = localThumbShape ?? globalThumbsShape,
@@ -46,7 +47,8 @@ export function OpacitySlider({
     thumbColor = localThumbColor ?? globalThumbsColor,
     renderThumb = localRenderThumb ?? globalRenderThumbs,
     thumbStyle = localThumbStyle ?? globalThumbsStyle ?? {},
-    thumbInnerStyle = localThumbInnerStyle ?? globalThumbsInnerStyle ?? {};
+    thumbInnerStyle = localThumbInnerStyle ?? globalThumbsInnerStyle ?? {},
+    sliderThickness = localSliderThickness ?? globalSliderThickness;
 
   const borderRadius = getStyle(style, 'borderRadius') ?? 5,
     getWidth = getStyle(style, 'width'),

--- a/src/components/Sliders/SaturationSlider.tsx
+++ b/src/components/Sliders/SaturationSlider.tsx
@@ -21,6 +21,7 @@ export function SaturationSlider({
   renderThumb: localRenderThumb,
   thumbStyle: localThumbStyle,
   thumbInnerStyle: localThumbInnerStyle,
+  sliderThickness: localSliderThickness,
   style = {},
   vertical = false,
   reverse = false,
@@ -31,13 +32,13 @@ export function SaturationSlider({
     hueValue,
     onGestureChange,
     onGestureEnd,
-    sliderThickness,
     thumbSize: globalThumbsSize,
     thumbShape: globalThumbsShape,
     thumbColor: globalThumbsColor,
     renderThumb: globalRenderThumbs,
     thumbStyle: globalThumbsStyle,
     thumbInnerStyle: globalThumbsInnerStyle,
+    sliderThickness: globalSliderThickness,
   } = useContext(CTX);
 
   const thumbShape = localThumbShape ?? globalThumbsShape,
@@ -45,7 +46,8 @@ export function SaturationSlider({
     thumbColor = localThumbColor ?? globalThumbsColor,
     renderThumb = localRenderThumb ?? globalRenderThumbs,
     thumbStyle = localThumbStyle ?? globalThumbsStyle ?? {},
-    thumbInnerStyle = localThumbInnerStyle ?? globalThumbsInnerStyle ?? {};
+    thumbInnerStyle = localThumbInnerStyle ?? globalThumbsInnerStyle ?? {},
+    sliderThickness = localSliderThickness ?? globalSliderThickness;
 
   const borderRadius = getStyle(style, 'borderRadius') ?? 5,
     getWidth = getStyle(style, 'width'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -279,6 +279,9 @@ export interface SliderProps {
   /** - function which receives ThumbProps and renders slider's handle (thumb). */
   renderThumb?: RenderThumbType;
 
+  /** - thickness is the width of the slider in vertical mode or the height in horizontal mode. */
+  sliderThickness?: number;
+
   /** - reverse slider direction. */
   reverse?: boolean;
 


### PR DESCRIPTION
This pull request adds a new prop called `sliderThickness` to every slider, allowing users to override the global thickness set in the parent component. The new prop is optional and defaults to the value set in the parent component.