### PR TITLE
Image source property

### DIFF
--- a/docusaurus/docs/API/Panel1.md
+++ b/docusaurus/docs/API/Panel1.md
@@ -22,6 +22,13 @@ description: A square-shaped slider, reminiscent of Adobe style, is utilized to 
 
 ## Props
 
+### `imageSource`
+
+- Allows for a higher quality image to be provided for the slider background.
+- Check out the `Figma` link for the uncompressed assets here 👉 [color picker assets](https://www.figma.com/file/1NAZsgrXejzzDsakZtQyuP/reanimated-color-picker-assets?node-id=0%3A1&t=CZzURph1MOPimwI2-1).
+- `type: ImageSourcePropType`
+- `default: undefined`
+
 ### `boundedThumb`
 
 - Determines whether the panel slider thumb (or handle) should be constrained to stay within the boundaries of the panel.

--- a/docusaurus/docs/API/Panel2.md
+++ b/docusaurus/docs/API/Panel2.md
@@ -22,6 +22,13 @@ description: A square-shaped slider (windows style) is utilized to adjust the hu
 
 ## Props
 
+### `imageSource`
+
+- Allows for a higher quality image to be provided for the slider background.
+- Check out the `Figma` link for the uncompressed assets here 👉 [color picker assets](https://www.figma.com/file/1NAZsgrXejzzDsakZtQyuP/reanimated-color-picker-assets?node-id=0%3A1&t=CZzURph1MOPimwI2-1).
+- `type: ImageSourcePropType`
+- `default: undefined`
+
 ### `boundedThumb`
 
 - Determines whether the panel slider thumb (or handle) should be constrained to stay within the boundaries of the panel.

--- a/docusaurus/docs/API/Panel3.md
+++ b/docusaurus/docs/API/Panel3.md
@@ -20,6 +20,13 @@ description: The circle-shaped slider, with its wheel style design, is utilized 
 
 ## Props
 
+### `imageSource`
+
+- Allows for a higher quality image to be provided for the slider background.
+- Check out the `Figma` link for the uncompressed assets here 👉 [color picker assets](https://www.figma.com/file/1NAZsgrXejzzDsakZtQyuP/reanimated-color-picker-assets?node-id=0%3A1&t=CZzURph1MOPimwI2-1).
+- `type: ImageSourcePropType`
+- `default: undefined`
+
 ### `boundedThumb`
 
 - Determines whether the panel slider thumb (or handle) should be constrained to stay within the boundaries of the panel.

--- a/docusaurus/docs/API/_slidersProps.mdx
+++ b/docusaurus/docs/API/_slidersProps.mdx
@@ -1,5 +1,12 @@
 ## Props
 
+### `imageSource`
+
+- Allows for a higher quality image to be provided for the slider background.
+- Check out the `Figma` link for the uncompressed assets here 👉 [color picker assets](https://www.figma.com/file/1NAZsgrXejzzDsakZtQyuP/reanimated-color-picker-assets?node-id=0%3A1&t=CZzURph1MOPimwI2-1).
+- `type: ImageSourcePropType`
+- `default: undefined`
+
 ### `boundedThumb`
 
 ![boundedThumb](../../../images/boundedThumb.png)

--- a/src/components/Panels/Panel1.tsx
+++ b/src/components/Panels/Panel1.tsx
@@ -21,6 +21,7 @@ export function Panel1({
   thumbStyle: localThumbStyle,
   thumbInnerStyle: localThumbInnerStyle,
   style = {},
+  imageSource,
 }: PanelProps) {
   const {
     hueValue,
@@ -115,7 +116,7 @@ export function Panel1({
         ]}
       >
         <ImageBackground
-          source={require('@assets/Panel1.png')}
+          source={imageSource ?? require('@assets/Panel1.png')}
           style={[styles.panel_image, { borderRadius }]}
           resizeMode='stretch'
         />

--- a/src/components/Panels/Panel2.tsx
+++ b/src/components/Panels/Panel2.tsx
@@ -22,6 +22,7 @@ export function Panel2({
   thumbInnerStyle: localThumbInnerStyle,
   reverse = false,
   style = {},
+  imageSource,
 }: Panel2Props) {
   const {
     hueValue,
@@ -105,7 +106,7 @@ export function Panel2({
         style={[styles.panel_container, { height: getHeight }, style, { position: 'relative', borderWidth: 0, padding: 0 }]}
       >
         <ImageBackground
-          source={require('@assets/Panel2.png')}
+          source={imageSource ?? require('@assets/Panel2.png')}
           style={[styles.panel_image, { borderRadius, transform: [{ scaleX: reverse ? -1 : 1 }] }]}
           resizeMode='stretch'
         />

--- a/src/components/Panels/Panel3.tsx
+++ b/src/components/Panels/Panel3.tsx
@@ -21,6 +21,7 @@ export function Panel3({
   thumbStyle: localThumbStyle,
   thumbInnerStyle: localThumbInnerStyle,
   style = {},
+  imageSource,
 }: PanelProps) {
   const {
     hueValue,
@@ -117,7 +118,7 @@ export function Panel3({
         onLayout={onLayout}
         style={[styles.panel_container, style, { position: 'relative', aspectRatio: 1, borderWidth: 0, padding: 0 }, panelStyle]}
       >
-        <ImageBackground source={require('@assets/Panel3.png')} style={styles.panel_image} resizeMode='stretch' />
+        <ImageBackground source={imageSource ?? require('@assets/Panel3.png')} style={styles.panel_image} resizeMode='stretch' />
         <Thumb
           {...{
             channel: 's',

--- a/src/components/Sliders/BrightnessSlider.tsx
+++ b/src/components/Sliders/BrightnessSlider.tsx
@@ -26,6 +26,7 @@ export function BrightnessSlider({
   style = {},
   vertical = false,
   reverse = false,
+  imageSource,
 }: SliderProps) {
   const {
     brightnessValue,
@@ -136,7 +137,7 @@ export function BrightnessSlider({
         onLayout={onLayout}
         style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
       >
-        <Animated.Image source={require('@assets/Brightness.png')} style={imageStyle} />
+        <Animated.Image source={imageSource ?? require('@assets/Brightness.png')} style={imageStyle} />
         <Thumb
           {...{
             channel: 'v',

--- a/src/components/Sliders/HueSlider.tsx
+++ b/src/components/Sliders/HueSlider.tsx
@@ -26,6 +26,7 @@ export function HueSlider({
   style = {},
   vertical = false,
   reverse = false,
+  imageSource,
 }: SliderProps) {
   const {
     onGestureChange,
@@ -139,7 +140,7 @@ export function HueSlider({
         onLayout={onLayout}
         style={[{ borderRadius }, style, thicknessStyle, { position: 'relative', borderWidth: 0, padding: 0 }]}
       >
-        <Animated.Image source={require('@assets/Hue.png')} style={imageStyle} />
+        <Animated.Image source={imageSource ?? require('@assets/Hue.png')} style={imageStyle} />
         {adaptSpectrum && (
           <>
             <Animated.View style={[{ borderRadius }, activeSaturationStyle, StyleSheet.absoluteFillObject]} />

--- a/src/components/Sliders/OpacitySlider.tsx
+++ b/src/components/Sliders/OpacitySlider.tsx
@@ -26,6 +26,7 @@ export function OpacitySlider({
   style = {},
   vertical = false,
   reverse = false,
+  imageSource,
 }: SliderProps) {
   const {
     alphaValue,
@@ -141,7 +142,7 @@ export function OpacitySlider({
         onLayout={onLayout}
         style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
       >
-        <Animated.Image source={require('@assets/Opacity.png')} style={imageStyle} />
+        <Animated.Image source={imageSource ?? require('@assets/Opacity.png')} style={imageStyle} />
         <Thumb
           {...{
             channel: 'a',

--- a/src/components/Sliders/SaturationSlider.tsx
+++ b/src/components/Sliders/SaturationSlider.tsx
@@ -26,6 +26,7 @@ export function SaturationSlider({
   style = {},
   vertical = false,
   reverse = false,
+  imageSource,
 }: SliderProps) {
   const {
     brightnessValue,
@@ -140,7 +141,7 @@ export function SaturationSlider({
         onLayout={onLayout}
         style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
       >
-        <Animated.Image source={require('@assets/Saturation.png')} style={imageStyle} />
+        <Animated.Image source={imageSource ?? require('@assets/Saturation.png')} style={imageStyle} />
         {adaptSpectrum && <Animated.View style={[{ borderRadius }, activeBrightnessStyle, StyleSheet.absoluteFillObject]} />}
         <Thumb
           {...{

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { StyleProp, TextStyle, ViewStyle, ImageStyle, TextInputProps } from 'react-native';
+import type { StyleProp, TextStyle, ViewStyle, ImageStyle, TextInputProps, ImageSourcePropType } from 'react-native';
 import type { AnimatedStyleProp, SharedValue } from 'react-native-reanimated';
 import type { AnyFormat } from './colorKit/types';
 
@@ -245,6 +245,12 @@ export interface PreviewTextProps {
 }
 
 export interface PanelProps {
+  /**
+   * - Allows for a higher quality image to be provided.
+   * - Check out the `Figma` link for the uncompressed assets here 👉 [color picker assets](https://www.figma.com/file/1NAZsgrXejzzDsakZtQyuP/reanimated-color-picker-assets?node-id=0%3A1&t=CZzURph1MOPimwI2-1).
+   */
+  imageSource?: ImageSourcePropType;
+
   /** - panel handle (thumb) size (height*width). */
   thumbSize?: number;
 
@@ -283,6 +289,12 @@ export interface Panel2Props extends PanelProps {
 }
 
 export interface SliderProps {
+  /**
+   * - Allows for a higher quality image to be provided.
+   * - Check out the `Figma` link for the uncompressed assets here 👉 [color picker assets](https://www.figma.com/file/1NAZsgrXejzzDsakZtQyuP/reanimated-color-picker-assets?node-id=0%3A1&t=CZzURph1MOPimwI2-1).
+   */
+  imageSource?: ImageSourcePropType;
+
   /** - slider's handle (thumb) size (height*width). */
   thumbSize?: number;
 


### PR DESCRIPTION
The purpose of this prop is to allow users to provide a higher quality background image for the sliders and panels. The default assets for the color picker are provided in an uncompressed format in a `Figma` file that can be downloaded from this link: [color picker assets](https://www.figma.com/file/1NAZsgrXejzzDsakZtQyuP/reanimated-color-picker-assets?node-id=0%3A1&t=CZzURph1MOPimwI2-1). You can use these assets as a starting point and scale them up or down as needed to fit your app's design.