### PR TITLE
Add a `reverse` prop to change the direction of the brightness or saturation channel.

### DIFF
--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -12,7 +12,7 @@
         "react-native": "0.68.2",
         "react-native-gesture-handler": "^2.5.0",
         "react-native-reanimated": "^2.9.1",
-        "reanimated-color-picker": "^2.2.0-beta.0"
+        "reanimated-color-picker": "^2.2.0-beta.4"
       },
       "devDependencies": {
         "@babel/core": "^7.12.9",
@@ -12895,9 +12895,9 @@
       "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
     },
     "node_modules/reanimated-color-picker": {
-      "version": "2.2.0-beta.0",
-      "resolved": "https://registry.npmjs.org/reanimated-color-picker/-/reanimated-color-picker-2.2.0-beta.0.tgz",
-      "integrity": "sha512-HY52LSSu6D4a9Son7pBYtpe7udpqkFanSLVMJLinLCT3vfhluymLw/2MBEJp5oNXmk1iUhsOzM/rjy1aGIUGlw==",
+      "version": "2.2.0-beta.4",
+      "resolved": "https://registry.npmjs.org/reanimated-color-picker/-/reanimated-color-picker-2.2.0-beta.4.tgz",
+      "integrity": "sha512-WmTF7zQmlHFFSbNip9o21DBgpo/eD7XpTS1FsGBvwly5FyslE15AiObLpvMsUZkdwSTpmZbesGUeX8LpEyL1QA==",
       "peerDependencies": {
         "expo": ">=44.0.0",
         "react-native-gesture-handler": ">=2.0.0",
@@ -24973,9 +24973,9 @@
       "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
     },
     "reanimated-color-picker": {
-      "version": "2.2.0-beta.0",
-      "resolved": "https://registry.npmjs.org/reanimated-color-picker/-/reanimated-color-picker-2.2.0-beta.0.tgz",
-      "integrity": "sha512-HY52LSSu6D4a9Son7pBYtpe7udpqkFanSLVMJLinLCT3vfhluymLw/2MBEJp5oNXmk1iUhsOzM/rjy1aGIUGlw==",
+      "version": "2.2.0-beta.4",
+      "resolved": "https://registry.npmjs.org/reanimated-color-picker/-/reanimated-color-picker-2.2.0-beta.4.tgz",
+      "integrity": "sha512-WmTF7zQmlHFFSbNip9o21DBgpo/eD7XpTS1FsGBvwly5FyslE15AiObLpvMsUZkdwSTpmZbesGUeX8LpEyL1QA==",
       "requires": {}
     },
     "recast": {

--- a/Example/package.json
+++ b/Example/package.json
@@ -13,7 +13,7 @@
     "react-native": "0.68.2",
     "react-native-gesture-handler": "^2.5.0",
     "react-native-reanimated": "^2.9.1",
-    "reanimated-color-picker": "^2.2.0-beta.0"
+    "reanimated-color-picker": "^2.2.0-beta.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/Example/src/Panel2Saturation.tsx
+++ b/Example/src/Panel2Saturation.tsx
@@ -34,7 +34,7 @@ export default function Example() {
                 thumbShape='rect'
                 onChange={onColorSelect}
               >
-                <Panel2 style={styles.panelStyle} thumbShape='ring' />
+                <Panel2 style={styles.panelStyle} thumbShape='ring' reverseVerticalChannel />
 
                 <BrightnessSlider style={styles.sliderStyle} />
 

--- a/Example/src/Panel5Example.tsx
+++ b/Example/src/Panel5Example.tsx
@@ -26,7 +26,7 @@ export default function Example() {
       <Modal onRequestClose={() => setShowModal(false)} visible={showModal} animationType='slide'>
         <Animated.View style={[styles.container, backgroundColorStyle]}>
           <View style={styles.pickerContainer}>
-            <ColorPicker value={initialColor} sliderThickness={25} thumbSize={24} thumbShape='circle' onChange={onColorSelect}>
+            <ColorPicker value={selectedColor.value} sliderThickness={25} thumbSize={24} thumbShape='circle' onChange={onColorSelect}>
               <Panel5 style={styles.panelStyle} />
 
               <OpacitySlider style={styles.sliderStyle} adaptSpectrum />

--- a/ExampleExpo/package-lock.json
+++ b/ExampleExpo/package-lock.json
@@ -17,7 +17,7 @@
         "react-native-gesture-handler": "~2.2.1",
         "react-native-reanimated": "~2.8.0",
         "react-native-web": "0.17.7",
-        "reanimated-color-picker": "^2.2.0-beta.0"
+        "reanimated-color-picker": "^2.2.0-beta.4"
       },
       "devDependencies": {
         "@babel/core": "^7.12.9"
@@ -15363,9 +15363,9 @@
       "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
     },
     "node_modules/reanimated-color-picker": {
-      "version": "2.2.0-beta.0",
-      "resolved": "https://registry.npmjs.org/reanimated-color-picker/-/reanimated-color-picker-2.2.0-beta.0.tgz",
-      "integrity": "sha512-HY52LSSu6D4a9Son7pBYtpe7udpqkFanSLVMJLinLCT3vfhluymLw/2MBEJp5oNXmk1iUhsOzM/rjy1aGIUGlw==",
+      "version": "2.2.0-beta.4",
+      "resolved": "https://registry.npmjs.org/reanimated-color-picker/-/reanimated-color-picker-2.2.0-beta.4.tgz",
+      "integrity": "sha512-WmTF7zQmlHFFSbNip9o21DBgpo/eD7XpTS1FsGBvwly5FyslE15AiObLpvMsUZkdwSTpmZbesGUeX8LpEyL1QA==",
       "peerDependencies": {
         "expo": ">=44.0.0",
         "react-native-gesture-handler": ">=2.0.0",
@@ -31524,9 +31524,9 @@
       "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg=="
     },
     "reanimated-color-picker": {
-      "version": "2.2.0-beta.0",
-      "resolved": "https://registry.npmjs.org/reanimated-color-picker/-/reanimated-color-picker-2.2.0-beta.0.tgz",
-      "integrity": "sha512-HY52LSSu6D4a9Son7pBYtpe7udpqkFanSLVMJLinLCT3vfhluymLw/2MBEJp5oNXmk1iUhsOzM/rjy1aGIUGlw==",
+      "version": "2.2.0-beta.4",
+      "resolved": "https://registry.npmjs.org/reanimated-color-picker/-/reanimated-color-picker-2.2.0-beta.4.tgz",
+      "integrity": "sha512-WmTF7zQmlHFFSbNip9o21DBgpo/eD7XpTS1FsGBvwly5FyslE15AiObLpvMsUZkdwSTpmZbesGUeX8LpEyL1QA==",
       "requires": {}
     },
     "recast": {

--- a/ExampleExpo/package.json
+++ b/ExampleExpo/package.json
@@ -19,7 +19,7 @@
     "react-native-gesture-handler": "~2.2.1",
     "react-native-reanimated": "~2.8.0",
     "react-native-web": "0.17.7",
-    "reanimated-color-picker": "^2.2.0-beta.0"
+    "reanimated-color-picker": "^2.2.0-beta.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/ExampleExpo/src/Panel2Brightness.jsx
+++ b/ExampleExpo/src/Panel2Brightness.jsx
@@ -34,7 +34,7 @@ export default function Example() {
                 onChange={onColorSelect}
                 adaptSpectrum
               >
-                <Panel2 style={styles.panelStyle} verticalChannel='brightness' thumbShape='ring' thumbSize={30} />
+                <Panel2 style={styles.panelStyle} verticalChannel='brightness' thumbShape='ring' thumbSize={30} reverseVerticalChannel />
 
                 <SaturationSlider style={styles.sliderStyle} thumbColor='#fff' />
 

--- a/ExampleExpo/src/Panel2Saturation.jsx
+++ b/ExampleExpo/src/Panel2Saturation.jsx
@@ -33,7 +33,7 @@ export default function Example() {
                 thumbShape='rect'
                 onChange={onColorSelect}
               >
-                <Panel2 style={styles.panelStyle} thumbShape='ring' />
+                <Panel2 style={styles.panelStyle} thumbShape='ring' reverseVerticalChannel />
 
                 <BrightnessSlider style={styles.sliderStyle} />
 

--- a/docusaurus/docs/API/Panel2.mdx
+++ b/docusaurus/docs/API/Panel2.mdx
@@ -81,9 +81,15 @@ import RenderThumb from './_renderThumb.mdx';
 - `type: boolean`
 - `default: false`
 
-### `reverse`
+### `reverseHue`
 
 - Reverse (flip) hue direction.
+- `type: boolean`
+- `default: false`
+
+### `reverseVerticalChannel`
+
+- Reverse (flip) the direction of the vertical channel's saturation or brightness.
 - `type: boolean`
 - `default: false`
 

--- a/docusaurus/docs/API/Panel4.mdx
+++ b/docusaurus/docs/API/Panel4.mdx
@@ -75,6 +75,12 @@ import RenderThumb from './_renderThumb.mdx';
 - `type: boolean`
 - `default: false`
 
+### `reverseHorizontalChannels`
+
+- Reverse (flip) the direction of the horizontal channel's brightness and saturation..
+- `type: boolean`
+- `default: false`
+
 ### `style`
 
 - Panel's container style.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reanimated-color-picker",
-  "version": "2.2.0-beta.2",
+  "version": "2.2.0-beta.4",
   "description": "A Pure JavaScript Color Picker for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/components/Panels/Panel2.tsx
+++ b/src/components/Panels/Panel2.tsx
@@ -23,6 +23,7 @@ export function Panel2({
   thumbInnerStyle: localThumbInnerStyle,
   verticalChannel = 'saturation',
   reverseHue = false,
+  reverseVerticalChannel = false,
   style = {},
 }: Panel2Props) {
   const {
@@ -64,9 +65,9 @@ export function Panel2({
       percentX = (hueValue.value / 360) * length.x,
       posX = (reverseHue ? length.x - percentX : percentX) - (boundedThumb ? 0 : thumbSize / 2),
       percentY = (channelValue.value / 100) * length.y,
-      posY = length.y - percentY - (boundedThumb ? 0 : thumbSize / 2);
+      posY = (reverseVerticalChannel ? percentY : length.y - percentY) - (boundedThumb ? 0 : thumbSize / 2);
     return { transform: [{ translateX: posX }, { translateY: posY }, { scale: handleScale.value }] };
-  }, [localThumbSize, reverseHue]);
+  }, [localThumbSize, reverseHue, reverseVerticalChannel]);
 
   const spectrumStyle = useAnimatedStyle(() => {
     if (!adaptSpectrum) return {};
@@ -84,7 +85,7 @@ export function Panel2({
       valueX = Math.round((posX / lengthX) * 360),
       valueY = Math.round((posY / lengthY) * 100),
       newHueValue = reverseHue ? 360 - valueX : valueX,
-      newChannelValue = 100 - valueY;
+      newChannelValue = reverseVerticalChannel ? valueY : 100 - valueY;
 
     if (hueValue.value === newHueValue && channelValue.value === newChannelValue) return;
 
@@ -117,9 +118,9 @@ export function Panel2({
     width: height.value,
     height: width.value,
     transform: [
-      { rotate: '270deg' },
-      { translateX: (width.value - height.value) / 2 },
-      { translateY: ((width.value - height.value) / 2) * (isRtl ? -1 : 1) },
+      { rotate: reverseVerticalChannel ? '90deg' : '270deg' },
+      { translateX: ((width.value - height.value) / 2) * (reverseVerticalChannel ? -1 : 1) },
+      { translateY: ((width.value - height.value) / 2) * (isRtl ? -1 : 1) * (reverseVerticalChannel ? -1 : 1) },
     ],
   }));
 

--- a/src/components/Panels/Panel4.tsx
+++ b/src/components/Panels/Panel4.tsx
@@ -21,7 +21,7 @@ export function Panel4({
   thumbStyle: localThumbStyle,
   thumbInnerStyle: localThumbInnerStyle,
   reverseHue = false,
-  reverseHorizontalChannels = true,
+  reverseHorizontalChannels = false,
   style = {},
 }: Panel4Props) {
   const {

--- a/src/types.ts
+++ b/src/types.ts
@@ -293,7 +293,7 @@ export interface Panel2Props extends PanelProps {
   /** - reverse (flip) hue direction. */
   reverseHue?: boolean;
 
-  /** - reverse (flip) the direction of the vertical channel (saturation or brightness). */
+  /** - reverse (flip) the direction of the vertical channel's saturation or brightness. */
   reverseVerticalChannel?: boolean;
 
   /** - determines which color channel to adjust when moving the thumb vertically on the slider. */
@@ -315,7 +315,7 @@ export interface Panel4Props extends PanelProps {
   /** - reverse (flip) hue direction. */
   reverseHue?: boolean;
 
-  /** - reverse (flip) the horizontal channels' brightness and saturation. */
+  /** - reverse (flip) the horizontal channel's brightness and saturation. */
   reverseHorizontalChannels?: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -314,6 +314,9 @@ export interface Panel3Props extends PanelProps {
 export interface Panel4Props extends PanelProps {
   /** - reverse (flip) hue direction. */
   reverseHue?: boolean;
+
+  /** - reverse (flip) the horizontal channels' brightness and saturation. */
+  reverseHorizontalChannels?: boolean;
 }
 
 export interface Panel5Props extends PanelProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -293,6 +293,9 @@ export interface Panel2Props extends PanelProps {
   /** - reverse (flip) hue direction. */
   reverseHue?: boolean;
 
+  /** - reverse (flip) the direction of the vertical channel (saturation or brightness). */
+  reverseVerticalChannel?: boolean;
+
   /** - determines which color channel to adjust when moving the thumb vertically on the slider. */
   verticalChannel?: 'saturation' | 'brightness';
 


### PR DESCRIPTION
- Add a `reverseVerticalChannel` prop to `Panel2` to change the direction of the vertical channel's brightness or saturation, depending on the value of the `verticalChannel` prop.
- Add a `reverseHorizontalChannels` prop to `Panel4` to change the direction of the horizontal channels' brightness and saturation.
