### PR TITLE
Add `disableAlphaChannel` prop to `InputWidget` component

### DIFF
--- a/docusaurus/docs/API/InputWidget.md
+++ b/docusaurus/docs/API/InputWidget.md
@@ -17,6 +17,12 @@ description: The input widget component allows you to input color values in vari
 - The `defaultFormat` prop determines the initial color format for the input widget component.
 - It accepts one of the following values: `'HEX' | 'RGB' | 'HSL' | 'HWB' | 'HSV'`
 
+### `disableAlphaChannel`
+
+- This prop allows you to disable the alpha channel input. If set to true, the input widget will ignore the alpha channel and prevent users from setting the opacity of the selected color.
+- `type: boolean`
+- `default: false`
+
 ### `formats`
 
 - The `formats` prop determines which color formats are included in the input widget component and the order they appear when cycling through them.

--- a/src/components/InputWidget/InputWidget.tsx
+++ b/src/components/InputWidget/InputWidget.tsx
@@ -1,9 +1,10 @@
 import React, { useContext, useState } from 'react';
 import { View, Text, Pressable, Image, StyleSheet } from 'react-native';
 
-import { styles } from '@styles';
 import { ConditionalRendering, getStyle } from '@utils';
 import pickerContext from '@context';
+import { styles } from '@styles';
+import colorKit from '@colorKit';
 import HexWidget from './Widgets/HexWidget';
 import RgbWidget from './Widgets/RgbWidget';
 import HslWidget from './Widgets/HslWidget';
@@ -18,6 +19,7 @@ export function InputWidget({
   defaultFormat = 'HEX',
   formats = defaultFormats,
   iconColor = 'black',
+  disableAlphaChannel = false,
   containerStyle = {},
   inputStyle = {},
   inputTitleStyle = {},
@@ -32,6 +34,9 @@ export function InputWidget({
   );
 
   const onChange = (color: string) => {
+    const isHex = colorKit.getFormat(color)?.includes('hex');
+    if (disableAlphaChannel && isHex) color = colorKit.setAlpha(color, 1).hex();
+
     setColor(color);
     onGestureChange(color);
     onGestureEnd(color);
@@ -53,6 +58,7 @@ export function InputWidget({
     inputStyle,
     inputTitleStyle,
     inputProps,
+    disableAlphaChannel,
   };
   const Input = () => {
     switch (format) {

--- a/src/components/InputWidget/Widgets/HslWidget.tsx
+++ b/src/components/InputWidget/Widgets/HslWidget.tsx
@@ -3,7 +3,7 @@ import { runOnJS, useDerivedValue } from 'react-native-reanimated';
 
 import WidgetTextInput from './WidgetTextInput';
 import colorKit from '@colorKit';
-import { clamp } from '@utils';
+import { clamp, ConditionalRendering } from '@utils';
 
 import type { WidgetProps } from '@types';
 
@@ -17,6 +17,7 @@ export default function HslWidget({
   inputStyle,
   inputTitleStyle,
   inputProps,
+  disableAlphaChannel,
 }: WidgetProps) {
   const [hslValues, setHslValues] = useState(colorKit.HSL(returnedResults().hsla).object());
 
@@ -96,17 +97,19 @@ export default function HslWidget({
         onFocus={onFocus}
         inputProps={inputProps}
       />
-      <WidgetTextInput
-        inputStyle={inputStyle}
-        textStyle={inputTitleStyle}
-        value={hslValues.a}
-        title='A'
-        onChange={onAlphaChange}
-        onBlur={onBlur}
-        onFocus={onFocus}
-        inputProps={inputProps}
-        decimal
-      />
+      <ConditionalRendering render={!disableAlphaChannel}>
+        <WidgetTextInput
+          inputStyle={inputStyle}
+          textStyle={inputTitleStyle}
+          value={hslValues.a}
+          title='A'
+          onChange={onAlphaChange}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          inputProps={inputProps}
+          decimal
+        />
+      </ConditionalRendering>
     </>
   );
 }

--- a/src/components/InputWidget/Widgets/HsvWidget.tsx
+++ b/src/components/InputWidget/Widgets/HsvWidget.tsx
@@ -3,7 +3,7 @@ import { runOnJS, useDerivedValue } from 'react-native-reanimated';
 
 import WidgetTextInput from './WidgetTextInput';
 import colorKit from '@colorKit';
-import { clamp } from '@utils';
+import { clamp, ConditionalRendering } from '@utils';
 
 import type { WidgetProps } from '@types';
 
@@ -17,6 +17,7 @@ export default function HsvWidget({
   inputStyle,
   inputTitleStyle,
   inputProps,
+  disableAlphaChannel,
 }: WidgetProps) {
   const [hsvValues, setHsvValues] = useState(colorKit.HSV(returnedResults().hsva).object());
 
@@ -96,17 +97,19 @@ export default function HsvWidget({
         onFocus={onFocus}
         inputProps={inputProps}
       />
-      <WidgetTextInput
-        inputStyle={inputStyle}
-        textStyle={inputTitleStyle}
-        value={hsvValues.a}
-        title='A'
-        onChange={onAlphaChange}
-        onBlur={onBlur}
-        onFocus={onFocus}
-        inputProps={inputProps}
-        decimal
-      />
+      <ConditionalRendering render={!disableAlphaChannel}>
+        <WidgetTextInput
+          inputStyle={inputStyle}
+          textStyle={inputTitleStyle}
+          value={hsvValues.a}
+          title='A'
+          onChange={onAlphaChange}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          inputProps={inputProps}
+          decimal
+        />
+      </ConditionalRendering>
     </>
   );
 }

--- a/src/components/InputWidget/Widgets/HwbWidget.tsx
+++ b/src/components/InputWidget/Widgets/HwbWidget.tsx
@@ -3,7 +3,7 @@ import { runOnJS, useDerivedValue } from 'react-native-reanimated';
 
 import WidgetTextInput from './WidgetTextInput';
 import colorKit from '@colorKit';
-import { clamp } from '@utils';
+import { clamp, ConditionalRendering } from '@utils';
 
 import type { WidgetProps } from '@types';
 
@@ -17,6 +17,7 @@ export default function HwbWidget({
   inputStyle,
   inputTitleStyle,
   inputProps,
+  disableAlphaChannel,
 }: WidgetProps) {
   const [hwbValues, setHwbValues] = useState(colorKit.HWB(returnedResults().hwba).object());
 
@@ -96,17 +97,19 @@ export default function HwbWidget({
         onFocus={onFocus}
         inputProps={inputProps}
       />
-      <WidgetTextInput
-        inputStyle={inputStyle}
-        textStyle={inputTitleStyle}
-        value={hwbValues.a}
-        title='A'
-        onChange={onAlphaChange}
-        onBlur={onBlur}
-        onFocus={onFocus}
-        inputProps={inputProps}
-        decimal
-      />
+      <ConditionalRendering render={!disableAlphaChannel}>
+        <WidgetTextInput
+          inputStyle={inputStyle}
+          textStyle={inputTitleStyle}
+          value={hwbValues.a}
+          title='A'
+          onChange={onAlphaChange}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          inputProps={inputProps}
+          decimal
+        />
+      </ConditionalRendering>
     </>
   );
 }

--- a/src/components/InputWidget/Widgets/RgbWidget.tsx
+++ b/src/components/InputWidget/Widgets/RgbWidget.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import { runOnJS, useDerivedValue } from 'react-native-reanimated';
 
 import colorKit from '@colorKit';
-import { clamp } from '@utils';
+import { clamp, ConditionalRendering } from '@utils';
 import WidgetTextInput from './WidgetTextInput';
 
 import type { WidgetProps } from '@types';
@@ -17,6 +17,7 @@ export default function RgbWidget({
   inputStyle,
   inputTitleStyle,
   inputProps,
+  disableAlphaChannel,
 }: WidgetProps) {
   const [rgbValues, setRgbValues] = useState(colorKit.RGB(returnedResults().rgba).object());
 
@@ -96,17 +97,19 @@ export default function RgbWidget({
         onFocus={onFocus}
         inputProps={inputProps}
       />
-      <WidgetTextInput
-        inputStyle={inputStyle}
-        textStyle={inputTitleStyle}
-        value={rgbValues.a}
-        title='A'
-        onChange={onAlphaChange}
-        onBlur={onBlur}
-        onFocus={onFocus}
-        inputProps={inputProps}
-        decimal
-      />
+      <ConditionalRendering render={!disableAlphaChannel}>
+        <WidgetTextInput
+          inputStyle={inputStyle}
+          textStyle={inputTitleStyle}
+          value={rgbValues.a}
+          title='A'
+          onChange={onAlphaChange}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          inputProps={inputProps}
+          decimal
+        />
+      </ConditionalRendering>
     </>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -411,6 +411,7 @@ export type WidgetProps = {
   inputStyle: StyleProp<TextStyle>;
   inputTitleStyle?: StyleProp<TextStyle>;
   inputProps: InputProps;
+  disableAlphaChannel: boolean;
 };
 
 type defaultFormats = 'HEX' | 'RGB' | 'HSL' | 'HWB' | 'HSV';
@@ -427,6 +428,9 @@ export interface InputWidgetProps {
    * - Available options: `'HEX'`, `'RGB'`, '`HSL'`, `'HWB'`, and `'HSV'`
    */
   formats?: readonly defaultFormats[];
+
+  /** - Limit the user's ability to modify the alpha channel of the selected color. */
+  disableAlphaChannel?: boolean;
 
   /** - `InputText` components style. */
   inputStyle?: StyleProp<TextStyle>;


### PR DESCRIPTION
This PR adds a new prop called `disableAlphaChannel` to the `InputWidget` component in order to allow users to prevent and ignore opacity inputs when selecting a color. This feature was requested by @KxmischesDomi in #32 

The `disableAlphaChannel` prop is a `boolean` value that, when set to true, disables the alpha channel input in the `InputWidget` component, preventing users from setting the opacity of the selected color. This prop provides more flexibility to users who want to limit the available color options and ensure consistent color representations across their application.

This PR also includes updates to the component's documentation to reflect the new `disableAlphaChannel` prop and its usage.