### PR TITLE
Allow Panel5 to properly parse initial color

### DIFF
--- a/src/components/Panels/Panel5.tsx
+++ b/src/components/Panels/Panel5.tsx
@@ -63,7 +63,7 @@ export function Panel5({ style = {}, selectionStyle = {} }: Panel5Props) {
   }, []);
 
   useEffect(() => {
-    const initialColor = colorKit.HEX(value.slice(0, 7)).toUpperCase();
+    const initialColor = colorKit.HEX(value).toUpperCase();
 
     const row = gridColors.findIndex(e => e.includes(initialColor));
     if (row === -1) return;


### PR DESCRIPTION
Panel5 was assuming the provided color would be a HEX color and was thus trying to preemptively trim the color down to the first 7 characters. This PR allows for colorKit to do all the processing for extracting the HEX initialColor.