### PR TITLE
♻️ use runOnUI for onComplete & onChange

### DIFF
--- a/src/ColorPicker.tsx
+++ b/src/ColorPicker.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle } from 'react';
 import { Text } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { useSharedValue, withTiming } from 'react-native-reanimated';
+import { runOnUI, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import { isWeb } from '@utils';
 import colorKit from '@colorKit';
@@ -69,12 +69,22 @@ const ColorPicker = forwardRef<ColorPickerRef, ColorPickerProps>(
       };
     };
 
-    const onGestureEnd = (color?: SupportedColorFormats) => {
+    const onCompleteWorklet = (color?: SupportedColorFormats) => {
+      'worklet';
       onComplete?.(returnedResults(color));
     };
 
-    const onGestureChange = (color?: SupportedColorFormats) => {
+    const onGestureEnd = (color?: SupportedColorFormats) => {
+      runOnUI(onCompleteWorklet)(color);
+    };
+
+    const onChangeWorklet = (color?: SupportedColorFormats) => {
+      'worklet';
       onChange?.(returnedResults(color));
+    };
+
+    const onGestureChange = (color?: SupportedColorFormats) => {
+      runOnUI(onChangeWorklet)(color);
     };
 
     const setColor = (color: string, duration = thumbAnimationDuration) => {


### PR DESCRIPTION
Hi, 
First of all, this lib seems great! One issue we had was that an expensive onComplete function will put a delay on the change of the thumb color like this: 

https://github.com/alabsi91/reanimated-color-picker/assets/60874935/7f4c5ba0-c1e2-4fed-9cab-8c7978816bf2

I've added runOnUI to these functions which gives us the right result: 


https://github.com/alabsi91/reanimated-color-picker/assets/60874935/f27f3b9f-6b63-4101-bf1c-3a8820e91480

Please let me know what you think!