### PR TITLE
Add `disableOpacityTexture` prop and fix opacity texture style for the `Preview` component

### DIFF
--- a/docusaurus/docs/API/Preview.md
+++ b/docusaurus/docs/API/Preview.md
@@ -37,6 +37,12 @@ description: The preview of the selected and the initial color.
 - `type: boolean`
 - `default: false`
 
+### `disableOpacityTexture`
+
+- Hide the preview background texture image that appears when the color has an opacity less than 1.
+- `type: boolean`
+- `default: false`
+
 ### `style`
 
 - Preview container style.

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -33,6 +33,7 @@ export function Preview({
   colorFormat = 'hex',
   hideInitialColor = false,
   hideText = false,
+  disableOpacityTexture = false,
 }: PreviewProps) {
   const { hueValue, saturationValue, brightnessValue, alphaValue, returnedResults, value } = useContext(pickerContext);
 
@@ -71,7 +72,7 @@ export function Preview({
   });
 
   return (
-    <Wrapper style={style}>
+    <Wrapper disableTexture={disableOpacityTexture} style={style}>
       <ConditionalRendering render={!hideInitialColor}>
         <View style={[styles.previewContainer, { backgroundColor: value, justifyContent }]}>
           <ConditionalRendering render={!hideText}>
@@ -91,7 +92,11 @@ export function Preview({
   );
 }
 
-function Wrapper({ children, style }: { children: ReactNode; style: {} | null }) {
+function Wrapper({ children, disableTexture, style }: { children: ReactNode; disableTexture: boolean; style: {} | null }) {
+  if (disableTexture) {
+    return <View style={[styles.previewWrapper, style]}>{children}</View>;
+  }
+
   if (isWeb) {
     return <View style={[styles.previewWrapper, previewWrapperWeb, style]}>{children}</View>;
   }

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -99,6 +99,7 @@ function Wrapper({ children, style }: { children: ReactNode; style: {} | null })
   return (
     <ImageBackground
       source={require('@assets/transparent-texture.png')}
+      imageStyle={{ width: '100%', height: '100%' }}
       resizeMode='repeat'
       style={[styles.previewWrapper, style]}
     >

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,9 @@ export interface PreviewProps {
   /** - hide color preview text. */
   hideText?: boolean;
 
+  /** - hide the preview background texture image that appears when the color has an opacity less than 1. */
+  disableOpacityTexture?: boolean;
+
   /**
    * - preview container style.
    * - **Note** Certain style properties will be overridden.


### PR DESCRIPTION
Add a prop `disableOpacityTexture` to hide the preview background texture image that appears when the color has an opacity less than 1.