### PR TITLE
[Panel5] Enhance Color Matching and Address Preview Color Alignment Issue

### DIFF
--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -3,6 +3,16 @@ import { I18nManager, Platform, StyleSheet } from 'react-native';
 
 import type { StyleProp, ViewStyle } from 'react-native';
 
+/** - To find the index of an element in a two-dimensional array. */
+export function findIndexIn2DArray<T>(array: T[][], evaluate: (target: T) => boolean) {
+  for (let i = 0; i < array.length; i++) {
+    for (let j = 0; j < array[i].length; j++) {
+      if (evaluate(array[i][j])) return [i, j];
+    }
+  }
+  return [null, null];
+}
+
 /** - Get a specific property from a react native style object */
 export function getStyle<T extends keyof ViewStyle>(style: StyleProp<ViewStyle>, property: T): ViewStyle[T] | undefined {
   const flattened = StyleSheet.flatten(style);


### PR DESCRIPTION
- Fix for #47 
- Now, Panel5 will attempt to match the color from the `value` prop with the grid colors while accounting for a margin of error. This is necessary because the color in the color picker undergoes various conversion steps, and the final result may not precisely match the original input color.

- Resolve the issue of the result color not aligning with the preview color in the `onChange` and `onComplete` events.