### PR TITLE
feat: Add 1renderCenterLine1 prop to Panel3

### DIFF
--- a/Example/src/Panel3Saturation.tsx
+++ b/Example/src/Panel3Saturation.tsx
@@ -32,7 +32,7 @@ export default function Example() {
                 <Preview style={styles.previewStyle} />
               </View>
 
-              <Panel3 style={styles.panelStyle} />
+              <Panel3 style={styles.panelStyle} renderCenterLine />
 
               <BrightnessSlider style={styles.sliderStyle} />
 

--- a/ExampleExpo/src/Panel3Saturation.jsx
+++ b/ExampleExpo/src/Panel3Saturation.jsx
@@ -31,7 +31,7 @@ export default function Example() {
                 <Preview style={styles.previewStyle} />
               </View>
 
-              <Panel3 style={styles.panelStyle} />
+              <Panel3 style={styles.panelStyle} renderCenterLine />
 
               <BrightnessSlider style={styles.sliderStyle} />
 

--- a/ExampleExpo/tsconfig.json
+++ b/ExampleExpo/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": {},
+  "extends": "expo/tsconfig.base"
+}

--- a/docs/docs/API/Panel3.mdx
+++ b/docs/docs/API/Panel3.mdx
@@ -22,11 +22,17 @@ If you want to give your users more control over the color selection, you can ad
 
 ## Props
 
-### `centerChannel `
+### `centerChannel`
 
 - Determines which color channel to adjust when moving the thumb towards or away from the center of the circular slider.
 - `type: "saturation" | "brightness"`
 - `default: "saturation"`
+
+### `renderCenterLine`
+
+- Controls whether to render a line from the center of the panel to the thumb (handle).
+- `type: boolean`
+- `default: false`
 
 ### `boundedThumb`
 

--- a/src/components/Panels/Panel3.tsx
+++ b/src/components/Panels/Panel3.tsx
@@ -24,6 +24,7 @@ export function Panel3({
   renderThumb: localRenderThumb,
   thumbStyle: localThumbStyle,
   thumbInnerStyle: localThumbInnerStyle,
+  renderCenterLine = false,
   centerChannel = 'saturation',
   style = {},
 }: Panel3Props) {
@@ -85,6 +86,23 @@ export function Panel3({
     if (centerChannel === 'brightness') return { backgroundColor: HSVA2HSLA_string(0, 0, 100, 1 - saturationValue.value / 100) };
     return { backgroundColor: HSVA2HSLA_string(0, 0, 0, 1 - brightnessValue.value / 100) };
   }, [adaptSpectrum, centerChannel, saturationValue, brightnessValue]);
+
+  const centerLineStyle = useAnimatedStyle(() => {
+    if (!renderCenterLine) return {};
+
+    const lineThickness = 1,
+      center = width.value / 2 - (boundedThumb ? thumbSize / 2 : 0),
+      distance = (channelValue.value / 100) * center,
+      angle = ((hueValue.value * Math.PI) / Math.PI + 180) % 360; // reversed angle
+
+    return {
+      top: (width.value - lineThickness) / 2,
+      left: (width.value - distance) / 2,
+      height: lineThickness,
+      width: distance,
+      transform: [{ rotate: angle + 'deg' }, { translateX: distance / 2 }, { translateY: 0 }],
+    };
+  }, [renderCenterLine, boundedThumb, thumbSize, width, hueValue, channelValue]);
 
   const onGestureUpdate = ({ x, y }: PanGestureHandlerEventPayload) => {
     'worklet';
@@ -151,6 +169,11 @@ export function Panel3({
             <Animated.View style={[{ borderRadius }, spectrumStyle, StyleSheet.absoluteFillObject]} />
           </ConditionalRendering>
         </ImageBackground>
+
+        <ConditionalRendering if={renderCenterLine}>
+          <Animated.View style={[styles.panel3Line, centerLineStyle]} />
+        </ConditionalRendering>
+
         <Thumb
           channel={centerChannel === 'brightness' ? 'v' : 's'}
           thumbShape={thumbShape}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -134,4 +134,20 @@ export const styles = StyleSheet.create({
     padding: 0,
     pointerEvents: 'none', // use along side the prop to be compatible with web platform
   },
+
+  // Panel3 line
+  panel3Line: {
+    position: 'absolute',
+    backgroundColor: '#ffffff',
+
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+    shadowOpacity: 0.2,
+    shadowRadius: 1.41,
+
+    elevation: 2,
+  },
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,6 +312,9 @@ export interface Panel3Props extends PanelProps {
 
   /** - color spectrum adapts to changes in brightness and saturation */
   adaptSpectrum?: boolean;
+
+  /** - render a line from the center of the Panel to the thumb (handle). */
+  renderCenterLine?: boolean;
 }
 
 export interface Panel4Props extends PanelProps {


### PR DESCRIPTION
## Description
This PR adds a new feature to `Panel3` by introducing the `renderCenterLine` prop. When set to `true`, a line will be rendered from the center to the thumb (handle) in the circular color picker.

## Changes Made
- Added the `renderCenterLine` prop to the `Panel3` component.
- Implemented the necessary logic to render the center line when the prop is set to `true`.
- Updated documentation and examples .
