### PR TITLE
Add `rotate` Prop to `HueCircular` Component for Hue Circle Rotation

### DIFF
--- a/docs/docs/API/Sliders/Hue/HueCircular.mdx
+++ b/docs/docs/API/Sliders/Hue/HueCircular.mdx
@@ -12,6 +12,12 @@ description: A slider to change the color's hue.
 
 ## Props
 
+### `rotate`
+
+- Specify a degree of rotation for the hue circle.
+- `type: number`
+- `default: 0`
+
 ### `thumbSize`
 
 - The size of the slider's thumb.

--- a/src/components/Sliders/Hue/HueCircular.tsx
+++ b/src/components/Sliders/Hue/HueCircular.tsx
@@ -12,7 +12,14 @@ import type { HueCircularProps } from '@types';
 import type { LayoutChangeEvent } from 'react-native';
 import type { PanGestureHandlerEventPayload } from 'react-native-gesture-handler';
 
-export function HueCircular({ children, gestures = [], style = {}, containerStyle = {}, ...props }: HueCircularProps) {
+export function HueCircular({
+  children,
+  gestures = [],
+  style = {},
+  containerStyle = {},
+  rotate = 0,
+  ...props
+}: HueCircularProps) {
   const { hueValue, saturationValue, brightnessValue, onGestureChange, onGestureEnd, ...ctx } = usePickerContext();
 
   const thumbShape = props.thumbShape ?? ctx.thumbShape,
@@ -33,17 +40,14 @@ export function HueCircular({ children, gestures = [], style = {}, containerStyl
 
   const handleStyle = useAnimatedStyle(() => {
     const center = width.value / 2,
+      rotatedHue = (hueValue.value - rotate) % 360,
       distance = (width.value - sliderThickness) / 2,
-      posY = width.value - (Math.sin((hueValue.value * Math.PI) / 180) * distance + center) - thumbSize / 2,
-      posX = width.value - (Math.cos((hueValue.value * Math.PI) / 180) * distance + center) - thumbSize / 2;
+      angle = (rotatedHue * Math.PI) / 180,
+      posY = width.value - (Math.sin(angle) * distance + center) - thumbSize / 2,
+      posX = width.value - (Math.cos(angle) * distance + center) - thumbSize / 2;
 
     return {
-      transform: [
-        { translateX: posX },
-        { translateY: posY },
-        { scale: handleScale.value },
-        { rotate: hueValue.value + 90 + 'deg' },
-      ],
+      transform: [{ translateX: posX }, { translateY: posY }, { scale: handleScale.value }, { rotate: rotatedHue + 90 + 'deg' }],
     };
   }, [width, hueValue, handleScale]);
 
@@ -61,6 +65,8 @@ export function HueCircular({ children, gestures = [], style = {}, containerStyl
 
   const clipViewStyle = useAnimatedStyle(() => {
     return {
+      position: 'absolute',
+      backgroundColor: '#fff',
       width: width.value - sliderThickness * 2,
       height: width.value - sliderThickness * 2,
       borderRadius: width.value / 2,
@@ -77,7 +83,7 @@ export function HueCircular({ children, gestures = [], style = {}, containerStyl
       dy = center - y,
       theta = Math.atan2(dy, dx) * (180 / Math.PI), // [0 - 180] range
       angle = theta < 0 ? 360 + theta : theta, // [0 - 360] range
-      newHueValue = angle;
+      newHueValue = (angle + rotate) % 360;
 
     if (hueValue.value === newHueValue) return;
 
@@ -136,6 +142,7 @@ export function HueCircular({ children, gestures = [], style = {}, containerStyl
         onLayout={onLayout}
         style={[
           styles.panel_container,
+          { justifyContent: 'center', alignItems: 'center' },
           style,
           { position: 'relative', aspectRatio: 1, borderWidth: 0, padding: 0 },
           borderRadiusStyle,
@@ -143,16 +150,17 @@ export function HueCircular({ children, gestures = [], style = {}, containerStyl
       >
         <ImageBackground
           source={require('@assets/circularHue.png')}
-          style={[styles.panel_image, { justifyContent: 'center', alignItems: 'center' }]}
+          style={[styles.panel_image, { transform: [{ rotate: -rotate + 'deg' }] }]}
           resizeMode='stretch'
         >
           <ConditionalRendering if={adaptSpectrum}>
             <Animated.View style={[borderRadiusStyle, activeBrightnessStyle, StyleSheet.absoluteFillObject]} />
             <Animated.View style={[borderRadiusStyle, activeSaturationStyle, StyleSheet.absoluteFillObject]} />
           </ConditionalRendering>
-
-          <Animated.View style={[clipViewStyle, { backgroundColor: '#fff' }, containerStyle]}>{children}</Animated.View>
         </ImageBackground>
+
+        <Animated.View style={[clipViewStyle, containerStyle]}>{children}</Animated.View>
+
         <Thumb
           channel='h'
           thumbShape={thumbShape}

--- a/src/types.ts
+++ b/src/types.ts
@@ -501,6 +501,9 @@ export interface HueCircularProps extends Omit<SliderProps, 'vertical' | 'revers
 
   /** - The style of the container that wraps the given children. */
   containerStyle?: StyleProp<ViewStyle>;
+
+  /** - Rotate the hue circle, from 0 to 360 */
+  rotate?: number;
 }
 
 export interface LuminanceCircularProps extends Omit<SliderProps, 'vertical' | 'reverse' | 'boundedThumb'> {


### PR DESCRIPTION
## Description:
This pull request introduces a new feature to the `HueCircular` component, enhancing the color picker by adding a `rotate` prop. The `rotate` prop allows users to specify a degree of rotation for the hue circle, This prop is optional, and if provided, it rotates the hue circle accordingly.