### PR TITLE
Fix `"ring"` Thumb Shape `BackgroundColor` Style + Refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reanimated-color-picker",
-  "version": "3.0.0",
+  "version": "3.0.1-rc0",
   "description": "A Pure JavaScript Color Picker for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/components/Sliders/HSL/LuminanceCircular.tsx
+++ b/src/components/Sliders/HSL/LuminanceCircular.tsx
@@ -80,7 +80,6 @@ export function LuminanceCircular({
   const clipViewStyle = useAnimatedStyle(() => {
     return {
       position: 'absolute',
-      backgroundColor: '#fff',
       width: width.value - sliderThickness * 2,
       height: width.value - sliderThickness * 2,
       borderRadius: width.value / 2,
@@ -176,7 +175,7 @@ export function LuminanceCircular({
           />
         </Animated.View>
 
-        <Animated.View style={[clipViewStyle, containerStyle]}>{children}</Animated.View>
+        <Animated.View style={[clipViewStyle, { backgroundColor: '#fff' }, containerStyle]}>{children}</Animated.View>
 
         <Thumb
           channel='v'

--- a/src/components/Sliders/Hue/HueCircular.tsx
+++ b/src/components/Sliders/Hue/HueCircular.tsx
@@ -68,7 +68,6 @@ export function HueCircular({
   const clipViewStyle = useAnimatedStyle(() => {
     return {
       position: 'absolute',
-      backgroundColor: '#fff',
       width: width.value - sliderThickness * 2,
       height: width.value - sliderThickness * 2,
       borderRadius: width.value / 2,
@@ -161,7 +160,7 @@ export function HueCircular({
           </ConditionalRendering>
         </ImageBackground>
 
-        <Animated.View style={[clipViewStyle, containerStyle]}>{children}</Animated.View>
+        <Animated.View style={[clipViewStyle, { backgroundColor: '#fff' }, containerStyle]}>{children}</Animated.View>
 
         <Thumb
           channel='h'

--- a/src/components/Thumb/BuiltinThumbs/DoubleTriangle.tsx
+++ b/src/components/Thumb/BuiltinThumbs/DoubleTriangle.tsx
@@ -37,7 +37,7 @@ export default function DoubleTriangle({
   };
   const adaptiveColorStyle = useAnimatedStyle(() => {
     return { borderBottomColor: thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   return (
     <Animated.View

--- a/src/components/Thumb/BuiltinThumbs/Hollow.tsx
+++ b/src/components/Thumb/BuiltinThumbs/Hollow.tsx
@@ -20,11 +20,11 @@ export default function Hollow({
 
   const adaptiveColorStyle = useAnimatedStyle(() => {
     return { borderColor: thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   const adaptiveColorBgStyle = useAnimatedStyle(() => {
     return { backgroundColor: thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   return (
     <Animated.View

--- a/src/components/Thumb/BuiltinThumbs/Line.tsx
+++ b/src/components/Thumb/BuiltinThumbs/Line.tsx
@@ -28,7 +28,7 @@ export default function Line({
 
   const adaptiveColorStyle = useAnimatedStyle(() => {
     return { backgroundColor: thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   return (
     <Animated.View

--- a/src/components/Thumb/BuiltinThumbs/Pill.tsx
+++ b/src/components/Thumb/BuiltinThumbs/Pill.tsx
@@ -28,7 +28,7 @@ export default function Pill({
 
   const adaptiveColorStyle = useAnimatedStyle(() => {
     return { borderColor: thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   return (
     <Animated.View

--- a/src/components/Thumb/BuiltinThumbs/Plus.tsx
+++ b/src/components/Thumb/BuiltinThumbs/Plus.tsx
@@ -33,11 +33,11 @@ export default function Plus({
 
   const adaptiveColorStyle = useAnimatedStyle(() => {
     return { backgroundColor: thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   const adaptiveBorderColorStyle = useAnimatedStyle(() => {
     return { borderColor: thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   return (
     <Animated.View

--- a/src/components/Thumb/BuiltinThumbs/Ring.tsx
+++ b/src/components/Thumb/BuiltinThumbs/Ring.tsx
@@ -29,11 +29,18 @@ export default function Ring({
   };
 
   const borderColor = getStyle(style, 'borderColor');
+  const ringBackgroundColor = getStyle(style, 'backgroundColor');
+
   const adaptiveColorStyle = useAnimatedStyle(() => {
-    const color = thumbColor ? colorKit.runOnUI().HEX(thumbColor) : adaptiveColor.value;
-    const backgroundColor = colorKit.runOnUI().setAlpha(color, 0.5).hex();
+    const backgroundColor =
+      ringBackgroundColor ??
+      colorKit
+        .runOnUI()
+        .setAlpha(thumbColor ?? adaptiveColor.value, 0.5)
+        .hex();
+
     return { backgroundColor, borderColor: borderColor ?? thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   // Make sure to match the parity (odd or even) of the parent width, to solve the centering issue
   const innerWidth = 0.75 * width;
@@ -41,7 +48,7 @@ export default function Ring({
 
   return (
     <Animated.View
-      style={[styles.handle, style, computedStyle, adaptiveColorStyle, handleStyle]}
+      style={[styles.handle, computedStyle, adaptiveColorStyle, style, handleStyle]}
       renderToHardwareTextureAndroid={enableAndroidHardwareTextures}
     >
       <Animated.View

--- a/src/components/Thumb/BuiltinThumbs/Ring.tsx
+++ b/src/components/Thumb/BuiltinThumbs/Ring.tsx
@@ -11,20 +11,16 @@ export default function Ring({
   width,
   height,
   borderRadius,
-  thumbColor,
   adaptiveColor,
   handleStyle,
   innerStyle,
   solidColor,
   style,
 }: BuiltinThumbsProps) {
-  const thumb_Color = thumbColor ? colorKit.HEX(thumbColor) : undefined;
-  const computedStyle = {
+  const ringStyle = {
     width,
     height,
     borderRadius,
-    backgroundColor: (thumb_Color || '#ffffff') + 50,
-    borderColor: thumbColor,
     borderWidth: 1,
   };
 
@@ -32,14 +28,10 @@ export default function Ring({
   const ringBackgroundColor = getStyle(style, 'backgroundColor');
 
   const adaptiveColorStyle = useAnimatedStyle(() => {
-    const backgroundColor =
-      ringBackgroundColor ??
-      colorKit
-        .runOnUI()
-        .setAlpha(thumbColor ?? adaptiveColor.value, 0.5)
-        .hex();
-
-    return { backgroundColor, borderColor: borderColor ?? thumbColor ?? adaptiveColor.value };
+    return {
+      backgroundColor: ringBackgroundColor ?? colorKit.runOnUI().setAlpha(adaptiveColor.value, 0.5).hex(),
+      borderColor: borderColor ?? adaptiveColor.value,
+    };
   }, [adaptiveColor]);
 
   // Make sure to match the parity (odd or even) of the parent width, to solve the centering issue
@@ -48,7 +40,7 @@ export default function Ring({
 
   return (
     <Animated.View
-      style={[styles.handle, computedStyle, adaptiveColorStyle, style, handleStyle]}
+      style={[styles.handle, ringStyle, adaptiveColorStyle, style, handleStyle]}
       renderToHardwareTextureAndroid={enableAndroidHardwareTextures}
     >
       <Animated.View

--- a/src/components/Thumb/BuiltinThumbs/TriangleDown.tsx
+++ b/src/components/Thumb/BuiltinThumbs/TriangleDown.tsx
@@ -33,7 +33,7 @@ export default function ({
 
   const adaptiveColorStyle = useAnimatedStyle(() => {
     return { borderBottomColor: thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   return (
     <Animated.View

--- a/src/components/Thumb/BuiltinThumbs/TriangleUp.tsx
+++ b/src/components/Thumb/BuiltinThumbs/TriangleUp.tsx
@@ -31,7 +31,7 @@ export default function TriangleUp({
 
   const adaptiveColorStyle = useAnimatedStyle(() => {
     return { borderBottomColor: thumbColor ?? adaptiveColor.value };
-  }, [thumbColor, adaptiveColor]);
+  }, [adaptiveColor]);
 
   return (
     <Animated.View


### PR DESCRIPTION
Allow changing the outer circle background color using `'thumbStyle'` and override both the adaptive and `thumbColor` styles.