### PR TITLE
Fix JS Compilation Conflict with Reanimated Babel Plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reanimated-color-picker",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A Pure JavaScript Color Picker for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/colorKit/index.ts
+++ b/src/colorKit/index.ts
@@ -21,7 +21,7 @@ import type {
 // this transformation can lead to a slow initial execution.
 // To address this issue, I consolidated them into a single worklet function.
 
-export function colorKitUI() {
+export const colorKitUI = () => {
   'worklet';
 
   const NAMED_COLORS = {
@@ -2066,7 +2066,7 @@ export function colorKitUI() {
     randomHwbColor,
     adjustContrast,
   };
-}
+};
 
 type ColorKit = ReturnType<typeof colorKitUI> & {
   /** - Initiates the asynchronous execution of a workletized colorKit function on the UI thread. */

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -13,13 +13,13 @@ export function getStyle<T extends keyof ViewStyle>(style: StyleProp<ViewStyle>,
 }
 
 /** - Clamp a number value between `0` and a max value */
-export function clamp(v: number, max: number) {
+export const clamp = (v: number, max: number) => {
   'worklet';
   return Math.min(Math.max(v, 0), max);
-}
+};
 
 /** - Convert `HSV` color to an `HSLA` string representation */
-export function HSVA2HSLA_string(h: number, s: number, v: number, a = 1) {
+export const HSVA2HSLA_string = (h: number, s: number, v: number, a = 1) => {
   'worklet';
 
   s = s / 100;
@@ -30,7 +30,7 @@ export function HSVA2HSLA_string(h: number, s: number, v: number, a = 1) {
     sln = l !== 0 && l !== 1 ? sl / (l < 0.5 ? l * 2 : 2 - l * 2) : sl;
 
   return `hsla(${h}, ${sln * 100}%, ${l * 100}%, ${a})`;
-}
+};
 
 /** - Render children only if the `render` property is `true` */
 export function ConditionalRendering(props: { children: React.ReactNode; if: boolean }) {


### PR DESCRIPTION
## Summary
This PR addresses a common JavaScript compilation issue caused by the Reanimated Babel plugin. The plugin converts worklet functions to arrow functions, which disrupts function hoisting and leads to runtime errors.

## Changes
Manually converted all affected worklet functions to arrow functions to ensure compatibility with the Reanimated Babel plugin.
