### PR TITLE
Fix: Resolve gesture detection issues in Panel5 with latest react-native-gesture-handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reanimated-color-picker",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "A Pure JavaScript Color Picker for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/components/Panels/Panel5.tsx
+++ b/src/components/Panels/Panel5.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { ImageBackground } from 'react-native';
+import { ImageBackground, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
@@ -106,15 +106,17 @@ export function Panel5({ gestures = [], style = {}, selectionStyle = {} }: Panel
 
   return (
     <GestureDetector gesture={composed}>
-      <ImageBackground
-        source={require('@assets/grid.png')}
-        onLayout={onLayout}
-        style={[style, { position: 'relative', borderWidth: 0, padding: 0, aspectRatio: 1.2 }]}
-        imageStyle={{ borderRadius }}
-        resizeMode='stretch'
-      >
-        <Animated.View style={[styles.selected, selectionStyle, selectedStyle]} />
-      </ImageBackground>
+      <View collapsable={false} style={{ flex: 1 }}>
+        <ImageBackground
+          source={require('@assets/grid.png')}
+          onLayout={onLayout}
+          style={[style, { position: 'relative', borderWidth: 0, padding: 0, aspectRatio: 1.2 }]}
+          imageStyle={{ borderRadius }}
+          resizeMode='stretch'
+        >
+          <Animated.View style={[styles.selected, selectionStyle, selectedStyle]} />
+        </ImageBackground>
+      </View>
     </GestureDetector>
   );
 }

--- a/src/components/Panels/Panel5.tsx
+++ b/src/components/Panels/Panel5.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { ImageBackground, View } from 'react-native';
+import { Image, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
@@ -106,16 +106,17 @@ export function Panel5({ gestures = [], style = {}, selectionStyle = {} }: Panel
 
   return (
     <GestureDetector gesture={composed}>
-      <View collapsable={false} style={{ flex: 1 }}>
-        <ImageBackground
+      <View
+        collapsable={false}
+        onLayout={onLayout}
+        style={[style, { position: 'relative', borderWidth: 0, padding: 0, aspectRatio: 1.2 }]}
+      >
+        <Image
           source={require('@assets/grid.png')}
-          onLayout={onLayout}
-          style={[style, { position: 'relative', borderWidth: 0, padding: 0, aspectRatio: 1.2 }]}
-          imageStyle={{ borderRadius }}
+          style={{ borderRadius, width: '100%', height: '100%' }}
           resizeMode='stretch'
-        >
-          <Animated.View style={[styles.selected, selectionStyle, selectedStyle]} />
-        </ImageBackground>
+        />
+        <Animated.View style={[styles.selected, selectionStyle, selectedStyle]} />
       </View>
     </GestureDetector>
   );


### PR DESCRIPTION
### Summary
This pull request addresses the `(NOBRIDGE) ERROR` in `react-native-gesture-handler` where the `GestureDetector` in `Panel5` fails to detect gestures due to view flattening. By wrapping the child components with `<View collapsable={false}>`, we ensure the views remain in the hierarchy and gesture handling works as intended.

### Problem
After upgrading to the latest version of `react-native-gesture-handler`, the `GestureDetector` in `Panel5` stopped working correctly. Specifically:
- **Observed Error**: `(NOBRIDGE) ERROR  [react-native-gesture-handler] GestureDetector has received a child that may get view-flattened. To prevent it from misbehaving you need to wrap the child with a <View collapsable={false}> . [Component Stack]`. 
- **Behavior Before**: This issue did not occur in earlier versions of `react-native-gesture-handler`, suggesting a recent change in gesture handling behavior.
- **Environment**: React Native `0.76.3`, `react-native-gesture-handler` `2.21.2`.

### Solution
The fix wraps the relevant child components in `<View collapsable={false}>`, ensuring that gesture detection functions correctly without view flattening. This change aligns with React Native's guidelines for preventing view flattening in gesture components.

### Testing
- **Environment**: Tested on React Native `0.76.3` with the latest version of `react-native-gesture-handler`.
- Confirmed that the error no longer occurs, and gestures in `Panel5` now function as expected.

### Notes
- This fix resolves the issue without introducing breaking changes. Other components and functionalities remain unaffected.
- It is recommended to document this change in case similar issues arise with future versions of `react-native-gesture-handler`.