### PR TITLE
Fix: Preview warnings

### DIFF
--- a/ExampleLatest/src/Panel3HslSaturation.tsx
+++ b/ExampleLatest/src/Panel3HslSaturation.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
 
@@ -8,7 +8,9 @@ import type { ColorFormatsObject } from 'reanimated-color-picker';
 export default function Example() {
   const [showModal, setShowModal] = useState(false);
 
-  const customSwatches = new Array(6).fill('#fff').map(() => colorKit.randomRgbColor().hex());
+  const customSwatches = useMemo(() => new Array(6).fill('#fff').map(() => colorKit.randomRgbColor().hex()), []);
+
+  const [currentValue, setCurrentValue] = useState(customSwatches[0]);
 
   const selectedColor = useSharedValue(customSwatches[0]);
   const backgroundColorStyle = useAnimatedStyle(() => ({ backgroundColor: selectedColor.value }));
@@ -17,6 +19,8 @@ export default function Example() {
     'worklet';
     selectedColor.value = color.hex;
   };
+
+  const onColorCompleteJS = (color: ColorFormatsObject) => setCurrentValue(color.hex);
 
   return (
     <>
@@ -28,11 +32,12 @@ export default function Example() {
         <Animated.View style={[styles.container, backgroundColorStyle]}>
           <View style={styles.pickerContainer}>
             <ColorPicker
-              value={selectedColor.value}
+              value={currentValue}
               sliderThickness={25}
               thumbShape='circle'
               thumbSize={25}
               onChange={onColorSelect}
+              onCompleteJS={onColorCompleteJS}
               adaptSpectrum
             >
               <View style={styles.previewContainer}>

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo } from 'react';
-import { ImageBackground, Text, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { ImageBackground, View } from 'react-native';
 import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue } from 'react-native-reanimated';
 
 import colorKit from '@colorKit';
@@ -24,11 +24,15 @@ export function Preview({
 
   const justifyContent = getStyle(style, 'justifyContent') ?? 'center';
 
-  const initialColorText = useMemo(() => {
+  const [initialValueFormatted, setInitialValueFormatted] = useState('');
+
+  useEffect(() => setInitialValueFormatted(returnedResults()[colorFormat]), [value, colorFormat]);
+
+  const initialColorText = useDerivedValue(() => {
     const adaptiveTextColor = alphaValue.value > 0.5 ? value : { h: 0, s: 0, v: 70 };
-    const contrast = colorKit.contrastRatio(adaptiveTextColor, '#ffffff');
+    const contrast = colorKit.runOnUI().contrastRatio(adaptiveTextColor, '#ffffff');
     const color = contrast < 4.5 ? '#000000' : '#ffffff';
-    return { formatted: returnedResults()[colorFormat], color };
+    return color;
   }, [value, colorFormat]);
 
   const textColor = useSharedValue<'#000000' | '#ffffff'>('#ffffff');
@@ -58,7 +62,9 @@ export function Preview({
       <ConditionalRendering if={!hideInitialColor}>
         <View style={[styles.previewContainer, { backgroundColor: value, justifyContent }]}>
           <ConditionalRendering if={!hideText}>
-            <Text style={[styles.previewText, { color: initialColorText.color }, textStyle]}>{initialColorText.formatted}</Text>
+            <Animated.Text style={[styles.previewText, { color: initialColorText }, textStyle]}>
+              {initialValueFormatted}
+            </Animated.Text>
           </ConditionalRendering>
         </View>
       </ConditionalRendering>

--- a/src/components/PreviewText.tsx
+++ b/src/components/PreviewText.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { TextInput } from 'react-native';
 import Animated, { useAnimatedProps, useAnimatedRef, useDerivedValue } from 'react-native-reanimated';
 
@@ -15,6 +15,10 @@ export function PreviewText({ style = {}, colorFormat = 'hex' }: PreviewTextProp
   const { returnedResults, hueValue, saturationValue, brightnessValue, alphaValue } = usePickerContext();
 
   const inputRef = useAnimatedRef<TextInput>();
+
+  const [defaultValue, setDefaultValue] = useState('');
+
+  useEffect(() => setDefaultValue(returnedResults()[colorFormat]), []);
 
   const colorString = useDerivedValue(() => {
     [colorFormat, hueValue, saturationValue, brightnessValue, alphaValue]; // track changes on Native
@@ -35,7 +39,7 @@ export function PreviewText({ style = {}, colorFormat = 'hex' }: PreviewTextProp
       ref={inputRef}
       underlineColorAndroid='transparent'
       editable={false}
-      defaultValue={colorString.value}
+      defaultValue={defaultValue}
       style={[styles.previewText, style]}
       animatedProps={animatedProps}
       pointerEvents='none'


### PR DESCRIPTION
### Description
Prevent accessing shared values in Preview components. This causes errors in react-native-reanimated strict mode.

This aspect can be neglected for one warning, but if the color picker value is constantly changing(ex: update the initial value in the **onCompleteJS** callback), a bunch of warnings will pollute the console.

<img width="647" alt="Screenshot 2025-04-05 at 19 28 22" src="https://github.com/user-attachments/assets/061cca14-a0a9-4182-8201-d18891160da1" />   

### Preparations
To reproduce this behavior you can copy the changes that I added to the **Panel3HslSaturation.tsx** file to update the initial value.

### Steps to reproduce:
- Run the **ExampleLatest**
- Open the **Panel3 HSL Saturation** 
- Perform any color change

You should see the warnings in the console. (x6 warnings for each initial color update)
