### PR TITLE
Update HWB color format to comply with React Native `0.79.0`

### DIFF
--- a/__tests__/colorConversion.test.ts
+++ b/__tests__/colorConversion.test.ts
@@ -423,9 +423,9 @@ describe('HEX to HWB Conversion', () => {
   for (let i = 0; i < colors.length; i++) {
     const { hex, hwb } = colors[i];
     for (let r = 0; r < hex.length; r++) {
-      test(`converts ${hex[r]} to ${hwb[0]}`, () => {
+      test(`converts ${hex[r]} to ${hwb[2]}`, () => {
         const color = colorKit.HWB(hex[r]).string();
-        expect(color).toBe(hwb[0]);
+        expect(color).toBe(hwb[2]);
       });
     }
   }
@@ -435,9 +435,9 @@ describe('RGB to HWB Conversion', () => {
   for (let i = 0; i < colors.length; i++) {
     const { rgb, hwb } = colors[i];
     for (let r = 0; r < rgb.length; r++) {
-      test(`converts ${rgb[r]} to ${hwb[0]}`, () => {
+      test(`converts ${rgb[r]} to ${hwb[2]}`, () => {
         const color = colorKit.HWB(rgb[r]).string();
-        expect(color).toBe(hwb[0]);
+        expect(color).toBe(hwb[2]);
       });
     }
   }
@@ -447,9 +447,9 @@ describe('HSL to HWB Conversion', () => {
   for (let i = 0; i < colors.length; i++) {
     const { hsl, hwb } = colors[i];
     for (let r = 0; r < hsl.length; r++) {
-      test(`converts ${hsl[r]} to ${hwb[0]}`, () => {
+      test(`converts ${hsl[r]} to ${hwb[2]}`, () => {
         const color = colorKit.HWB(hsl[r]).string();
-        expect(color).toBe(hwb[0]);
+        expect(color).toBe(hwb[2]);
       });
     }
   }
@@ -459,9 +459,9 @@ describe('HSV to HWB Conversion', () => {
   for (let i = 0; i < colors.length; i++) {
     const { hsv, hwb } = colors[i];
     for (let r = 0; r < hsv.length; r++) {
-      test(`converts ${hsv[r]} to ${hwb[0]}`, () => {
+      test(`converts ${hsv[r]} to ${hwb[2]}`, () => {
         const color = colorKit.HWB(hsv[r]).string();
-        expect(color).toBe(hwb[0]);
+        expect(color).toBe(hwb[2]);
       });
     }
   }
@@ -471,9 +471,9 @@ describe('HWB to HWB Conversion', () => {
   for (let i = 0; i < colors.length; i++) {
     const { hwb } = colors[i];
     for (let r = 0; r < hwb.length; r++) {
-      test(`converts ${hwb[r]} to ${hwb[0]}`, () => {
+      test(`converts ${hwb[r]} to ${hwb[2]}`, () => {
         const color = colorKit.HWB(hwb[r]).string();
-        expect(color).toBe(hwb[0]);
+        expect(color).toBe(hwb[2]);
       });
     }
   }

--- a/src/colorKit/index.ts
+++ b/src/colorKit/index.ts
@@ -198,6 +198,7 @@ export const colorKitUI = () => {
 
     hwb: [
       /^hwb\s*\(\s*(\d{1,3})(?:deg)?\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*\)$/i,
+      /^hwb\s*\(\s*(\d{1,3})\s+([\d.]+)%\s+([\d.]+)%\s+\/\s*(\d|\d\.\d+)\s*\)$/i,
       /^hwb\s*\(\s*(\d{1,3})(?:deg)?\s+([\d.]+)%\s+([\d.]+)%\s*\)$/i,
     ],
     hwba: [
@@ -812,13 +813,13 @@ export const colorKitUI = () => {
 
         // auto
         if (typeof forceAlpha === 'undefined') {
-          if (typeof a === 'number' && a !== 1) return `hwba(${h}, ${w}%, ${b}%, ${a})`;
-          return `hwb(${h}, ${w}%, ${b}%)`;
+          if (typeof a === 'number' && a !== 1) return `hwb(${h} ${w}% ${b}% / ${a})`;
+          return `hwb(${h} ${w}% ${b}%)`;
         }
 
-        if (forceAlpha) return `hwba(${h}, ${w}%, ${b}%, ${a ?? 1})`;
+        if (forceAlpha) return `hwb(${h} ${w}% ${b}% / ${a ?? 1})`;
 
-        return `hwb(${h}, ${w}%, ${b}%)`;
+        return `hwb(${h} ${w}% ${b}%)`;
       },
       array: (roundValues = true) => {
         if (roundValues) {


### PR DESCRIPTION
- See https://github.com/facebook/react-native/commit/676359efd9e478d69ad430cff213acc87b273580
- React Native still doesn't support HWB with an alpha channel `hwb(number number% number% / float)` I opened an issue here https://github.com/facebook/react-native/issues/50583