### PR TITLE
Fix Transform and Border Radius Issue in Color Picker on Android (API 24-28)

### DIFF
--- a/src/components/Panels/Panel1.tsx
+++ b/src/components/Panels/Panel1.tsx
@@ -104,9 +104,8 @@ export function Panel1({ gestures = [], style = {}, ...props }: PanelProps) {
         onLayout={onLayout}
         style={[
           styles.panel_container,
-          { height: getHeight },
           style,
-          { position: 'relative', borderWidth: 0, padding: 0 },
+          { position: 'relative', height: getHeight, borderWidth: 0, padding: 0 },
           activeColorStyle,
         ]}
       >

--- a/src/components/Panels/Panel2.tsx
+++ b/src/components/Panels/Panel2.tsx
@@ -154,7 +154,7 @@ export function Panel2({
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[styles.panel_container, { height: getHeight }, style, { position: 'relative', borderWidth: 0, padding: 0 }]}
+        style={[styles.panel_container, style, { position: 'relative', height: getHeight, borderWidth: 0, padding: 0 }]}
       >
         <ImageBackground
           source={require('@assets/Hue.png')}

--- a/src/components/Panels/Panel4.tsx
+++ b/src/components/Panels/Panel4.tsx
@@ -121,13 +121,15 @@ export function Panel4({
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[styles.panel_container, { height: getHeight }, style, { position: 'relative', borderWidth: 0, padding: 0 }]}
+        style={[styles.panel_container, style, { position: 'relative', height: getHeight, borderWidth: 0, padding: 0 }]}
       >
-        <Animated.Image
-          source={require('@assets/Hue.png')}
-          style={[styles.panel_image, { borderRadius }, panelImageStyle]}
-          resizeMode='stretch'
-        />
+        <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
+          <Animated.Image
+            source={require('@assets/Hue.png')}
+            style={[styles.panel_image, panelImageStyle]}
+            resizeMode='stretch'
+          />
+        </View>
 
         <View
           style={[

--- a/src/components/Sliders/HSB/BrightnessSlider.tsx
+++ b/src/components/Sliders/HSB/BrightnessSlider.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
@@ -54,7 +55,6 @@ export function BrightnessSlider({ gestures = [], style = {}, vertical = false, 
     return {
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      borderRadius,
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? -1 : 1) : 0 },
@@ -106,9 +106,12 @@ export function BrightnessSlider({ gestures = [], style = {}, vertical = false, 
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
+        style={[style, { position: 'relative', borderRadius, borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
       >
-        <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+        <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
+          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+        </View>
+
         <Thumb
           channel='v'
           thumbShape={thumbShape}

--- a/src/components/Sliders/HSB/SaturationSlider.tsx
+++ b/src/components/Sliders/HSB/SaturationSlider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
@@ -60,7 +60,7 @@ export function SaturationSlider({ gestures = [], style = {}, vertical = false, 
     return {
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      borderRadius,
+      tintColor: '#fff',
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? -1 : 1) : 0 },
@@ -112,9 +112,11 @@ export function SaturationSlider({ gestures = [], style = {}, vertical = false, 
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
+        style={[style, { position: 'relative', borderRadius, borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
       >
-        <Animated.Image source={require('@assets/blackGradient.png')} style={[imageStyle, { tintColor: '#fff' }]} />
+        <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
+          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+        </View>
 
         <ConditionalRendering if={adaptSpectrum}>
           <Animated.View style={[{ borderRadius }, activeBrightnessStyle, StyleSheet.absoluteFillObject]} />

--- a/src/components/Sliders/HSL/HSLSaturationSlider.tsx
+++ b/src/components/Sliders/HSL/HSLSaturationSlider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated';
 
@@ -72,7 +72,7 @@ export function HSLSaturationSlider({ gestures = [], style = {}, vertical = fals
     return {
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      borderRadius,
+      tintColor: '#888',
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? -1 : 1) : 0 },
@@ -131,9 +131,11 @@ export function HSLSaturationSlider({ gestures = [], style = {}, vertical = fals
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
+        style={[style, { position: 'relative', borderRadius, borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
       >
-        <Animated.Image source={require('@assets/blackGradient.png')} style={[imageStyle, { tintColor: '#888' }]} />
+        <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
+          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+        </View>
 
         <ConditionalRendering if={adaptSpectrum}>
           <Animated.View style={[{ borderRadius }, activeBrightnessStyle, StyleSheet.absoluteFillObject]} />

--- a/src/components/Sliders/HSL/LuminanceSlider.tsx
+++ b/src/components/Sliders/HSL/LuminanceSlider.tsx
@@ -7,7 +7,7 @@ import colorKit from '@colorKit';
 import usePickerContext from '@context';
 import { styles } from '@styles';
 import Thumb from '@thumb';
-import { clamp, getStyle, isRtl } from '@utils';
+import { clamp, enableAndroidHardwareTextures, getStyle, isRtl } from '@utils';
 
 import type { SliderProps } from '@types';
 import type { LayoutChangeEvent } from 'react-native';
@@ -123,9 +123,12 @@ export function LuminanceSlider({ gestures = [], style = {}, vertical = false, r
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
+        style={[style, { borderRadius, position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
       >
-        <Animated.View style={[styles.panel_image, imageStyle, { borderRadius, flexDirection: isRtl ? 'row-reverse' : 'row' }]}>
+        <Animated.View
+          style={[styles.panel_image, imageStyle, { borderRadius, flexDirection: isRtl ? 'row-reverse' : 'row' }]}
+          renderToHardwareTextureAndroid={enableAndroidHardwareTextures}
+        >
           <Image source={require('@assets/blackGradient.png')} style={{ flex: 1, tintColor: '#fff' }} resizeMode='stretch' />
           <Image
             source={require('@assets/blackGradient.png')}

--- a/src/components/Sliders/Hue/HueSlider.tsx
+++ b/src/components/Sliders/Hue/HueSlider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
@@ -63,7 +63,6 @@ export function HueSlider({ gestures = [], style = {}, vertical = false, reverse
     return {
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      borderRadius,
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? -1 : 1) : 0 },
@@ -115,9 +114,11 @@ export function HueSlider({ gestures = [], style = {}, vertical = false, reverse
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[{ borderRadius }, style, thicknessStyle, { position: 'relative', borderWidth: 0, padding: 0 }]}
+        style={[style, thicknessStyle, { position: 'relative', borderRadius, borderWidth: 0, padding: 0 }]}
       >
-        <Animated.Image source={require('@assets/Hue.png')} style={imageStyle} />
+        <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
+          <Animated.Image source={require('@assets/Hue.png')} style={imageStyle} />
+        </View>
 
         <ConditionalRendering if={adaptSpectrum}>
           <Animated.View style={[{ borderRadius }, activeBrightnessStyle, StyleSheet.absoluteFillObject]} />

--- a/src/components/Sliders/OpacitySlider.tsx
+++ b/src/components/Sliders/OpacitySlider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, StyleSheet } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
@@ -71,7 +71,7 @@ export function OpacitySlider({ gestures = [], style = {}, vertical = false, rev
         adaptSpectrum ? saturationValue.value : 100,
         adaptSpectrum ? brightnessValue.value : 100,
       ),
-      borderRadius,
+      // borderRadius,
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? 1 : -1) : 0 },
@@ -124,9 +124,8 @@ export function OpacitySlider({ gestures = [], style = {}, vertical = false, rev
       <Animated.View
         onLayout={onLayout}
         style={[
-          { borderRadius },
           style,
-          { position: 'relative', borderWidth: 0, padding: 0 },
+          { position: 'relative', borderRadius, borderWidth: 0, padding: 0 },
           thicknessStyle,
           isWeb ? webTransparentTexture : {},
         ]}
@@ -137,7 +136,9 @@ export function OpacitySlider({ gestures = [], style = {}, vertical = false, rev
             style={[{ width: '100%', height: '100%', borderRadius }, StyleSheet.absoluteFill]}
             resizeMode='repeat'
           />
-          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} resizeMode='stretch' />
+          <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
+            <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} resizeMode='stretch' />
+          </View>
         </RenderNativeOnly>
 
         <RenderWebOnly>

--- a/src/components/Sliders/RGB/BlueSlider.tsx
+++ b/src/components/Sliders/RGB/BlueSlider.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated';
 
@@ -57,7 +58,6 @@ export function BlueSlider({ gestures = [], style = {}, vertical = false, revers
       tintColor: `rgb(${Math.round(rgb.value.r)}, ${Math.round(rgb.value.g)}, 255)`,
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      borderRadius,
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? 1 : -1) : 0 },
@@ -125,11 +125,14 @@ export function BlueSlider({ gestures = [], style = {}, vertical = false, revers
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, redGreen]}
+        style={[style, { position: 'relative', borderRadius, borderWidth: 0, padding: 0 }, thicknessStyle, redGreen]}
       >
         <RenderNativeOnly>
-          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+          <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
+            <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+          </View>
         </RenderNativeOnly>
+
         <Thumb
           thumbShape={thumbShape}
           thumbSize={thumbSize}

--- a/src/components/Sliders/RGB/GreenSlider.tsx
+++ b/src/components/Sliders/RGB/GreenSlider.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated';
 
@@ -57,7 +58,6 @@ export function GreenSlider({ gestures = [], style = {}, vertical = false, rever
       tintColor: `rgb(${Math.round(rgb.value.r)}, 255, ${Math.round(rgb.value.b)})`,
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      borderRadius,
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? 1 : -1) : 0 },
@@ -125,10 +125,12 @@ export function GreenSlider({ gestures = [], style = {}, vertical = false, rever
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, redBlue]}
+        style={[style, { position: 'relative', borderRadius, borderWidth: 0, padding: 0 }, thicknessStyle, redBlue]}
       >
         <RenderNativeOnly>
-          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+          <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
+            <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+          </View>
         </RenderNativeOnly>
         <Thumb
           thumbShape={thumbShape}

--- a/src/components/Sliders/RGB/RedSlider.tsx
+++ b/src/components/Sliders/RGB/RedSlider.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { useAnimatedStyle, useDerivedValue, useSharedValue, withTiming } from 'react-native-reanimated';
 
@@ -57,7 +58,6 @@ export function RedSlider({ gestures = [], style = {}, vertical = false, reverse
       tintColor: `rgb(255, ${Math.round(rgb.value.g)}, ${Math.round(rgb.value.b)})`,
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      borderRadius,
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? 1 : -1) : 0 },
@@ -125,11 +125,14 @@ export function RedSlider({ gestures = [], style = {}, vertical = false, reverse
     <GestureDetector gesture={composed}>
       <Animated.View
         onLayout={onLayout}
-        style={[{ borderRadius }, style, { position: 'relative', borderWidth: 0, padding: 0 }, thicknessStyle, greenBlue]}
+        style={[style, { position: 'relative', borderRadius, borderWidth: 0, padding: 0 }, thicknessStyle, greenBlue]}
       >
         <RenderNativeOnly>
-          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+          <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
+            <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+          </View>
         </RenderNativeOnly>
+
         <Thumb
           thumbShape={thumbShape}
           thumbSize={thumbSize}


### PR DESCRIPTION
Addresses a React Native issue https://github.com/facebook/react-native/issues/18266 where using `transform` with `borderRadius` causes rendering issues on Android API levels 24-28. 
Updated the component to handle this edge case.