### PR TITLE
fix: resolve react native web deprecation warnings

### DIFF
--- a/src/ColorPicker.tsx
+++ b/src/ColorPicker.tsx
@@ -10,16 +10,10 @@ import { isWeb } from '@utils';
 import type { ColorPickerContext, ColorPickerProps, ColorPickerRef } from '@types';
 import type { SupportedColorFormats } from './colorKit/types';
 
-if (isWeb) {
+// @ts-expect-error no global
+if (isWeb && !global.setImmediate) {
   // @ts-expect-error no global
-  if (!global.setImmediate) global.setImmediate = setTimeout;
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { enableExperimentalWebImplementation } = require('react-native-gesture-handler');
-    enableExperimentalWebImplementation(true);
-  } catch (error) {
-    // ignore
-  }
+  global.setImmediate = setTimeout;
 }
 
 const ColorPicker = forwardRef<ColorPickerRef, ColorPickerProps>(

--- a/src/components/InputWidget/InputWidget.tsx
+++ b/src/components/InputWidget/InputWidget.tsx
@@ -89,7 +89,7 @@ export function InputWidget({
       <ConditionalRendering if={formats.length > 1}>
         <View style={{ width: iconWidth }}>
           <Pressable onPress={cycle}>
-            <Image style={[buttonIconStyle, { tintColor: iconColor }]} source={require('@assets/arrow-icon.png')} />
+            <Image style={buttonIconStyle} tintColor={iconColor} source={require('@assets/arrow-icon.png')} />
           </Pressable>
           <Text style={styles.inputTitle}> </Text>
         </View>

--- a/src/components/Panels/Panel1.tsx
+++ b/src/components/Panels/Panel1.tsx
@@ -110,11 +110,7 @@ export function Panel1({ gestures = [], style = {}, ...props }: PanelProps) {
         ]}
       >
         <View style={[styles.panel_image, { borderRadius }]}>
-          <Image
-            source={require('@assets/blackGradient.png')}
-            style={[styles.panel_image, { tintColor: '#fff' }]}
-            resizeMode='stretch'
-          />
+          <Image source={require('@assets/blackGradient.png')} style={styles.panel_image} tintColor='#fff' resizeMode='stretch' />
           <Animated.Image
             source={require('@assets/blackGradient.png')}
             style={[styles.panel_image, brightnessImageStyle]}

--- a/src/components/Panels/Panel2.tsx
+++ b/src/components/Panels/Panel2.tsx
@@ -167,13 +167,8 @@ export function Panel2({
 
           <Animated.Image
             source={require('@assets/blackGradient.png')}
-            style={[
-              styles.panel_image,
-              panelImageStyle,
-              {
-                tintColor: verticalChannel === 'saturation' ? '#fff' : verticalChannel === 'hsl-saturation' ? '#888' : undefined,
-              },
-            ]}
+            style={[styles.panel_image, panelImageStyle]}
+            tintColor={verticalChannel === 'saturation' ? '#fff' : verticalChannel === 'hsl-saturation' ? '#888' : undefined}
             resizeMode='stretch'
           />
 

--- a/src/components/Panels/Panel3/Panel3.tsx
+++ b/src/components/Panels/Panel3/Panel3.tsx
@@ -217,10 +217,8 @@ export function Panel3({
 
             <Image
               source={require('@assets/blackRadial.png')}
-              style={[
-                styles.panel_image,
-                { tintColor: centerChannel === 'saturation' ? '#fff' : centerChannel === 'hsl-saturation' ? '#888' : undefined },
-              ]}
+              style={styles.panel_image}
+              tintColor={centerChannel === 'saturation' ? '#fff' : centerChannel === 'hsl-saturation' ? '#888' : undefined}
               resizeMode='stretch'
             />
 

--- a/src/components/Panels/Panel4.tsx
+++ b/src/components/Panels/Panel4.tsx
@@ -141,7 +141,7 @@ export function Panel4({
             },
           ]}
         >
-          <Image source={require('@assets/blackGradient.png')} style={{ flex: 1, tintColor: '#fff' }} resizeMode='stretch' />
+          <Image source={require('@assets/blackGradient.png')} style={{ flex: 1 }} tintColor='#fff' resizeMode='stretch' />
           <Image
             source={require('@assets/blackGradient.png')}
             style={{ flex: 1, transform: [{ scaleX: -1 }] }}

--- a/src/components/PreviewText.tsx
+++ b/src/components/PreviewText.tsx
@@ -23,7 +23,8 @@ export function PreviewText({ style = {}, colorFormat = 'hex' }: PreviewTextProp
   }, []);
 
   const colorString = useDerivedValue(() => {
-    [colorFormat, hueValue, saturationValue, brightnessValue, alphaValue]; // track changes on Native
+    // Explicitly touch dependencies so Reanimated tracks them and doesn’t prune the worklet
+    (() => [colorFormat, hueValue, saturationValue, brightnessValue, alphaValue])();
 
     if (isWeb && inputRef.current) {
       // @ts-expect-error value doesn't exist
@@ -32,7 +33,7 @@ export function PreviewText({ style = {}, colorFormat = 'hex' }: PreviewTextProp
     }
 
     return returnedResults()[colorFormat];
-  }, [colorFormat, hueValue, saturationValue, brightnessValue, alphaValue]); // track changes on WEB
+  }, [colorFormat, hueValue, saturationValue, brightnessValue, alphaValue]);
 
   const animatedProps = useAnimatedProps(() => ({ text: colorString.value }) as never, [colorString]);
 
@@ -44,7 +45,7 @@ export function PreviewText({ style = {}, colorFormat = 'hex' }: PreviewTextProp
       defaultValue={defaultValue}
       style={[styles.previewText, style]}
       animatedProps={animatedProps}
-      pointerEvents='none'
+      pointerEvents={isWeb ? undefined : 'none'}
     />
   );
 }

--- a/src/components/Sliders/HSB/SaturationSlider.tsx
+++ b/src/components/Sliders/HSB/SaturationSlider.tsx
@@ -60,7 +60,6 @@ export function SaturationSlider({ gestures = [], style = {}, vertical = false, 
     return {
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      tintColor: '#fff',
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? -1 : 1) : 0 },
@@ -115,7 +114,7 @@ export function SaturationSlider({ gestures = [], style = {}, vertical = false, 
         style={[style, { position: 'relative', borderRadius, borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
       >
         <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
-          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} tintColor='#fff' />
         </View>
 
         <ConditionalRendering if={adaptSpectrum}>

--- a/src/components/Sliders/HSL/HSLSaturationSlider.tsx
+++ b/src/components/Sliders/HSL/HSLSaturationSlider.tsx
@@ -72,7 +72,6 @@ export function HSLSaturationSlider({ gestures = [], style = {}, vertical = fals
     return {
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      tintColor: '#888',
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? -1 : 1) : 0 },
@@ -134,7 +133,7 @@ export function HSLSaturationSlider({ gestures = [], style = {}, vertical = fals
         style={[style, { position: 'relative', borderRadius, borderWidth: 0, padding: 0 }, thicknessStyle, activeColorStyle]}
       >
         <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
-          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} />
+          <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} tintColor='#888' />
         </View>
 
         <ConditionalRendering if={adaptSpectrum}>

--- a/src/components/Sliders/HSL/LuminanceSlider.tsx
+++ b/src/components/Sliders/HSL/LuminanceSlider.tsx
@@ -129,7 +129,7 @@ export function LuminanceSlider({ gestures = [], style = {}, vertical = false, r
           style={[styles.panel_image, imageStyle, { borderRadius, flexDirection: isRtl ? 'row-reverse' : 'row' }]}
           renderToHardwareTextureAndroid={enableAndroidHardwareTextures}
         >
-          <Image source={require('@assets/blackGradient.png')} style={{ flex: 1, tintColor: '#fff' }} resizeMode='stretch' />
+          <Image source={require('@assets/blackGradient.png')} style={{ flex: 1 }} tintColor='#fff' resizeMode='stretch' />
           <Image
             source={require('@assets/blackGradient.png')}
             style={{ flex: 1, transform: [{ scaleX: -1 }] }}

--- a/src/components/Sliders/OpacitySlider.tsx
+++ b/src/components/Sliders/OpacitySlider.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Image, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import Animated, { useAnimatedProps, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 
 import usePickerContext from '@context';
 import Thumb from '@thumb';
@@ -66,12 +66,6 @@ export function OpacitySlider({ gestures = [], style = {}, vertical = false, rev
     return {
       width: vertical ? height.value : '100%',
       height: vertical ? width.value : '100%',
-      tintColor: HSVA2HSLA_string(
-        hueValue.value,
-        adaptSpectrum ? saturationValue.value : 100,
-        adaptSpectrum ? brightnessValue.value : 100,
-      ),
-      // borderRadius,
       transform: [
         { rotate: imageRotate },
         { translateX: vertical ? ((height.value - width.value) / 2) * (reverse ? 1 : -1) : 0 },
@@ -79,6 +73,16 @@ export function OpacitySlider({ gestures = [], style = {}, vertical = false, rev
       ],
     };
   }, [width, height, hueValue, saturationValue, brightnessValue]);
+
+  const imageTintColorProp = useAnimatedProps(() => {
+    return {
+      tintColor: HSVA2HSLA_string(
+        hueValue.value,
+        adaptSpectrum ? saturationValue.value : 100,
+        adaptSpectrum ? brightnessValue.value : 100,
+      ),
+    };
+  }, [hueValue, saturationValue, brightnessValue]);
 
   const onGestureUpdate = ({ x, y }: PanGestureHandlerEventPayload) => {
     'worklet';
@@ -137,7 +141,12 @@ export function OpacitySlider({ gestures = [], style = {}, vertical = false, rev
             resizeMode='repeat'
           />
           <View style={{ flex: 1, borderRadius, overflow: 'hidden' }}>
-            <Animated.Image source={require('@assets/blackGradient.png')} style={imageStyle} resizeMode='stretch' />
+            <Animated.Image
+              source={require('@assets/blackGradient.png')}
+              style={imageStyle}
+              resizeMode='stretch'
+              animatedProps={imageTintColorProp}
+            />
           </View>
         </RenderNativeOnly>
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -35,15 +35,20 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
   },
   shadow: {
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
+    ...Platform.select({
+      web: { boxShadow: 'rgba(0, 0, 0, 0.3) 0px 0px 2px' },
+      default: {
+        shadowColor: '#000',
+        shadowOffset: {
+          width: 0,
+          height: 1,
+        },
+        shadowOpacity: 0.2,
+        shadowRadius: 1.41,
 
-    elevation: 5,
+        elevation: 2,
+      },
+    }),
   },
   triangle: {
     width: 0,
@@ -102,16 +107,20 @@ export const styles = StyleSheet.create({
     borderRadius: 15,
     marginHorizontal: 5,
     marginBottom: 15,
+    ...Platform.select({
+      web: { boxShadow: 'rgba(0, 0, 0, 0.3) 0px 0px 7px' },
+      default: {
+        shadowColor: '#000',
+        shadowOffset: {
+          width: 0,
+          height: 1,
+        },
+        shadowOpacity: 0.2,
+        shadowRadius: 1.41,
 
-    shadowColor: '#000',
-    shadowOffset: {
-      width: 0,
-      height: 2,
-    },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-
-    elevation: 5,
+        elevation: 2,
+      },
+    }),
   },
 
   // Preview
@@ -139,7 +148,6 @@ export const styles = StyleSheet.create({
   panel3Line: {
     position: 'absolute',
     backgroundColor: '#ffffff',
-
     ...Platform.select({
       web: { boxShadow: 'rgba(0, 0, 0, 0.3) 0px 0px 2px' },
       default: {


### PR DESCRIPTION
- Replace shadowColor/shadowOffset/shadowOpacity/shadowRadius with Platform.select using boxShadow for web
- Move tintColor from StyleSheet to Image component props for better web compatibility
- Update Image components to use tintColor prop instead of style
- Use useAnimatedProps for dynamic tintColor in OpacitySlider
- Fix PreviewText dependencies tracking in useDerivedValue worklet
- Simplify ColorPicker web initialization by removing unnecessary try-catch