### PR TITLE
fix: move defaultValue into animatedProps to prevent stale value on re-attach

### DIFF
--- a/src/components/InputWidget/Widgets/WidgetTextInput.tsx
+++ b/src/components/InputWidget/Widgets/WidgetTextInput.tsx
@@ -35,7 +35,7 @@ export default function WidgetTextInput({
 }: Props) {
   const inputRef = useAnimatedRef<TextInput>();
 
-  const animatedProps = useAnimatedProps(() => ({ text: textValue.value }) as never, [textValue]);
+  const animatedProps = useAnimatedProps(() => ({ text: textValue.value, defaultValue: textValue.value }) as never, [textValue]);
 
   const submit = (e: TextInputEndEditingEvent | BlurEvent) => {
     // @ts-expect-error text doesn't exist on BlurEvent
@@ -75,7 +75,6 @@ export default function WidgetTextInput({
       <AnimatedTextInput
         ref={inputRef}
         style={[styles.input, inputStyle]}
-        defaultValue={textValue.value}
         maxLength={decimal ? 4 : textKeyboard ? 9 : 3} // length example: Alpha (1.55), RGB (255), Hue (360), Brightness (100), hex (#00000000)
         onEndEditing={submit}
         onBlur={isWeb ? submit : undefined}

--- a/src/components/PreviewText.tsx
+++ b/src/components/PreviewText.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useState } from 'react';
-import { TextInput } from 'react-native';
-import Animated, { useAnimatedProps, useAnimatedRef, useDerivedValue } from 'react-native-reanimated';
-
 import usePickerContext from '@context';
 import { styles } from '@styles';
 import { isWeb } from '@utils';
+import React from 'react';
+import { TextInput } from 'react-native';
+import Animated, { useAnimatedProps, useAnimatedRef, useDerivedValue } from 'react-native-reanimated';
 
 import type { PreviewTextProps } from '@types';
 
@@ -15,12 +14,6 @@ export function PreviewText({ style = {}, colorFormat = 'hex' }: PreviewTextProp
   const { returnedResults, hueValue, saturationValue, brightnessValue, alphaValue } = usePickerContext();
 
   const inputRef = useAnimatedRef<TextInput>();
-
-  const [defaultValue, setDefaultValue] = useState('');
-
-  useEffect(() => {
-    setDefaultValue(returnedResults()[colorFormat]);
-  }, []);
 
   const colorString = useDerivedValue(() => {
     // Explicitly touch dependencies so Reanimated tracks them and doesn’t prune the worklet
@@ -35,14 +28,16 @@ export function PreviewText({ style = {}, colorFormat = 'hex' }: PreviewTextProp
     return returnedResults()[colorFormat];
   }, [colorFormat, hueValue, saturationValue, brightnessValue, alphaValue]);
 
-  const animatedProps = useAnimatedProps(() => ({ text: colorString.value }) as never, [colorString]);
+  const animatedProps = useAnimatedProps(
+    () => ({ text: colorString.value, defaultValue: colorString.value }) as never,
+    [colorString],
+  );
 
   return (
     <AnimatedTextInput
       ref={inputRef}
       underlineColorAndroid='transparent'
       editable={false}
-      defaultValue={defaultValue}
       style={[styles.previewText, style]}
       animatedProps={animatedProps}
       pointerEvents={isWeb ? undefined : 'none'}


### PR DESCRIPTION
When React Navigation re-attaches the screen, `defaultValue` was taking priority over the animated value since the worklet never re-fires if shared values haven't changed.

Moving `defaultValue` into `animatedProps` ensures both `text` and `defaultValue` are driven by Reanimated together, so there's no stale static prop to override on re-attachment.

Fixes #103